### PR TITLE
Triton data converter (CMSSW_11_2_0_pre9)

### DIFF
--- a/HeterogeneousCore/SonicTriton/interface/TritonConverterBase.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonConverterBase.h
@@ -9,8 +9,10 @@
 template <typename DT>
 class TritonConverterBase {
 public:
-  TritonConverterBase(const edm::ParameterSet& conf) : converterName_(conf.getParameter<std::string>("converterName")), byteSize_(sizeof(DT)) {}
-  TritonConverterBase(const edm::ParameterSet& conf, size_t byteSize) : converterName_(conf.getParameter<std::string>("converterName")), byteSize_(byteSize) {}
+  TritonConverterBase(const edm::ParameterSet& conf)
+      : converterName_(conf.getParameter<std::string>("converterName")), byteSize_(sizeof(DT)) {}
+  TritonConverterBase(const edm::ParameterSet& conf, size_t byteSize)
+      : converterName_(conf.getParameter<std::string>("converterName")), byteSize_(byteSize) {}
   TritonConverterBase(const TritonConverterBase&) = delete;
   virtual ~TritonConverterBase() = default;
   TritonConverterBase& operator=(const TritonConverterBase&) = delete;

--- a/HeterogeneousCore/SonicTriton/interface/TritonConverterBase.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonConverterBase.h
@@ -1,0 +1,35 @@
+#ifndef __TritonConverterBase_H__
+#define __TritonConverterBase_H__
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/Common/interface/Handle.h"
+
+#include <string>
+
+template <typename DT>
+class TritonConverterBase {
+public:
+  TritonConverterBase(const edm::ParameterSet& conf) : converterName_(conf.getParameter<std::string>("converterName")), byteSize_(sizeof(DT)) {}
+  TritonConverterBase(const edm::ParameterSet& conf, size_t byteSize) : converterName_(conf.getParameter<std::string>("converterName")), byteSize_(byteSize) {}
+  TritonConverterBase(const TritonConverterBase&) = delete;
+  virtual ~TritonConverterBase() = default;
+  TritonConverterBase& operator=(const TritonConverterBase&) = delete;
+
+  virtual const uint8_t* convertIn(const DT* in) = 0;
+  virtual const DT* convertOut(const uint8_t* in) = 0;
+
+  virtual const int64_t getByteSize() const { return byteSize_; }
+
+  const std::string& name() const { return converterName_; }
+
+private:
+  const std::string converterName_;
+  const int64_t byteSize_;
+};
+
+#include "FWCore/PluginManager/interface/PluginFactory.h"
+
+template <typename DT>
+using TritonConverterFactory = edmplugin::PluginFactory<TritonConverterBase<DT>*(const edm::ParameterSet&)>;
+
+#endif

--- a/HeterogeneousCore/SonicTriton/interface/TritonData.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonData.h
@@ -4,6 +4,8 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/Span.h"
 
+#include "HeterogeneousCore/SonicTriton/interface/TritonConverterBase.h"
+
 #include <vector>
 #include <string>
 #include <unordered_map>
@@ -39,6 +41,13 @@ public:
   //some members can be modified
   bool setShape(const ShapeType& newShape) { return setShape(newShape, true); }
   bool setShape(unsigned loc, int64_t val) { return setShape(loc, val, true); }
+
+  void setConverterParams(const edm::ParameterSet& conf) {
+    converterConf_ = conf;
+    converterName_ = conf.getParameter<std::string>("converterName");
+  }
+  template <typename DT>
+  std::unique_ptr<TritonConverterBase<DT>> createConverter() const;
 
   //io accessors
   template <typename DT>
@@ -93,6 +102,8 @@ private:
   int64_t byteSize_;
   std::any holder_;
   std::shared_ptr<Result> result_;
+  edm::ParameterSet converterConf_;
+  std::string converterName_;
 };
 
 using TritonInputData = TritonData<nvidia::inferenceserver::client::InferInput>;
@@ -107,6 +118,12 @@ void TritonInputData::toServer(std::shared_ptr<TritonInput<DT>> ptr);
 template <>
 template <typename DT>
 TritonOutput<DT> TritonOutputData::fromServer() const;
+template <>
+template <typename DT>
+std::unique_ptr<TritonConverterBase<DT>> TritonOutputData::createConverter() const;
+template <>
+template <typename DT>
+std::unique_ptr<TritonConverterBase<DT>> TritonInputData::createConverter() const;
 template <>
 void TritonInputData::reset();
 template <>

--- a/HeterogeneousCore/SonicTriton/plugins/BuildFile.xml
+++ b/HeterogeneousCore/SonicTriton/plugins/BuildFile.xml
@@ -1,0 +1,11 @@
+<library   name="HeterogeneousCoreSonicTritonPlugins_converters" file="converters/*.cc">
+  <use   name="FWCore/Utilities"/>
+  <use   name="FWCore/ParameterSet"/>
+  <use   name="FWCore/PluginManager"/>
+  <use   name="DataFormats/Common"/>
+  <use   name="HeterogeneousCore/SonicTriton"/>
+  <use   name="triton-inference-server"/>
+  <use   name="protobuf"/>
+  <use   name="hls"/>
+  <flags   EDM_PLUGIN="1"/>
+</library>

--- a/HeterogeneousCore/SonicTriton/plugins/converters/FloatApFixed16Converter.cc
+++ b/HeterogeneousCore/SonicTriton/plugins/converters/FloatApFixed16Converter.cc
@@ -2,26 +2,23 @@
 
 #include "ap_fixed.h"
 
-template<int I>
+template <int I>
 class FloatApFixed16Converter : public TritonConverterBase<float> {
 public:
-  FloatApFixed16Converter(const edm::ParameterSet& conf)
-      : TritonConverterBase<float>(conf, 2) {
-      }
+  FloatApFixed16Converter(const edm::ParameterSet& conf) : TritonConverterBase<float>(conf, 2) {}
 
   const uint8_t* convertIn(const float* in) override;
   const float* convertOut(const uint8_t* in) override;
 
 private:
-
-  std::vector<ap_fixed<16,I>> makeVecIn(const float *in) {
-    unsigned int nfeat = sizeof(in)/sizeof(float);
-    std::vector<ap_fixed<16,I>> temp_storage(in, in + nfeat);
+  std::vector<ap_fixed<16, I>> makeVecIn(const float* in) {
+    unsigned int nfeat = sizeof(in) / sizeof(float);
+    std::vector<ap_fixed<16, I>> temp_storage(in, in + nfeat);
     return temp_storage;
   }
 
-  std::vector<float> makeVecOut(const ap_fixed<16,I> *in) {
-    unsigned int nfeat = sizeof(in)/sizeof(ap_fixed<16,I>);
+  std::vector<float> makeVecOut(const ap_fixed<16, I>* in) {
+    unsigned int nfeat = sizeof(in) / sizeof(ap_fixed<16, I>);
     std::vector<float> temp_storage(in, in + nfeat);
     return temp_storage;
   }
@@ -29,12 +26,12 @@ private:
 
 DEFINE_EDM_PLUGIN(TritonConverterFactory<float>, FloatApFixed16Converter<6>, "FloatApFixed16F6Converter");
 
-template<int I>
-const uint8_t* FloatApFixed16Converter<I>::convertIn(const float *in) {
-    return reinterpret_cast<const uint8_t*>((this->makeVecIn(in)).data());
+template <int I>
+const uint8_t* FloatApFixed16Converter<I>::convertIn(const float* in) {
+  return reinterpret_cast<const uint8_t*>((this->makeVecIn(in)).data());
 }
 
-template<int I>
+template <int I>
 const float* FloatApFixed16Converter<I>::convertOut(const uint8_t* in) {
-    return (this->makeVecOut(reinterpret_cast<const ap_fixed<16,I>*>(in))).data();
+  return (this->makeVecOut(reinterpret_cast<const ap_fixed<16, I>*>(in))).data();
 }

--- a/HeterogeneousCore/SonicTriton/plugins/converters/FloatApFixed16Converter.cc
+++ b/HeterogeneousCore/SonicTriton/plugins/converters/FloatApFixed16Converter.cc
@@ -1,0 +1,40 @@
+#include "HeterogeneousCore/SonicTriton/interface/TritonConverterBase.h"
+
+#include "ap_fixed.h"
+
+template<int I>
+class FloatApFixed16Converter : public TritonConverterBase<float> {
+public:
+  FloatApFixed16Converter(const edm::ParameterSet& conf)
+      : TritonConverterBase<float>(conf, 2) {
+      }
+
+  const uint8_t* convertIn(const float* in) override;
+  const float* convertOut(const uint8_t* in) override;
+
+private:
+
+  std::vector<ap_fixed<16,I>> makeVecIn(const float *in) {
+    unsigned int nfeat = sizeof(in)/sizeof(float);
+    std::vector<ap_fixed<16,I>> temp_storage(in, in + nfeat);
+    return temp_storage;
+  }
+
+  std::vector<float> makeVecOut(const ap_fixed<16,I> *in) {
+    unsigned int nfeat = sizeof(in)/sizeof(ap_fixed<16,I>);
+    std::vector<float> temp_storage(in, in + nfeat);
+    return temp_storage;
+  }
+};
+
+DEFINE_EDM_PLUGIN(TritonConverterFactory<float>, FloatApFixed16Converter<6>, "FloatApFixed16F6Converter");
+
+template<int I>
+const uint8_t* FloatApFixed16Converter<I>::convertIn(const float *in) {
+    return reinterpret_cast<const uint8_t*>((this->makeVecIn(in)).data());
+}
+
+template<int I>
+const float* FloatApFixed16Converter<I>::convertOut(const uint8_t* in) {
+    return (this->makeVecOut(reinterpret_cast<const ap_fixed<16,I>*>(in))).data();
+}

--- a/HeterogeneousCore/SonicTriton/plugins/converters/FloatStandardConverter.cc
+++ b/HeterogeneousCore/SonicTriton/plugins/converters/FloatStandardConverter.cc
@@ -2,8 +2,7 @@
 
 class FloatStandardConverter : public TritonConverterBase<float> {
 public:
-  FloatStandardConverter(const edm::ParameterSet& conf)
-      : TritonConverterBase<float>(conf) {}
+  FloatStandardConverter(const edm::ParameterSet& conf) : TritonConverterBase<float>(conf) {}
 
   const uint8_t* convertIn(const float* in) override;
   const float* convertOut(const uint8_t* in) override;
@@ -11,10 +10,6 @@ public:
 
 DEFINE_EDM_PLUGIN(TritonConverterFactory<float>, FloatStandardConverter, "FloatStandardConverter");
 
-const uint8_t* FloatStandardConverter::convertIn(const float *in) {
-    return reinterpret_cast<const uint8_t*>(in);
-}
+const uint8_t* FloatStandardConverter::convertIn(const float* in) { return reinterpret_cast<const uint8_t*>(in); }
 
-const float* FloatStandardConverter::convertOut(const uint8_t* in) {
-    return reinterpret_cast<const float*>(in);
-}
+const float* FloatStandardConverter::convertOut(const uint8_t* in) { return reinterpret_cast<const float*>(in); }

--- a/HeterogeneousCore/SonicTriton/plugins/converters/FloatStandardConverter.cc
+++ b/HeterogeneousCore/SonicTriton/plugins/converters/FloatStandardConverter.cc
@@ -1,0 +1,20 @@
+#include "HeterogeneousCore/SonicTriton/interface/TritonConverterBase.h"
+
+class FloatStandardConverter : public TritonConverterBase<float> {
+public:
+  FloatStandardConverter(const edm::ParameterSet& conf)
+      : TritonConverterBase<float>(conf) {}
+
+  const uint8_t* convertIn(const float* in) override;
+  const float* convertOut(const uint8_t* in) override;
+};
+
+DEFINE_EDM_PLUGIN(TritonConverterFactory<float>, FloatStandardConverter, "FloatStandardConverter");
+
+const uint8_t* FloatStandardConverter::convertIn(const float *in) {
+    return reinterpret_cast<const uint8_t*>(in);
+}
+
+const float* FloatStandardConverter::convertOut(const uint8_t* in) {
+    return reinterpret_cast<const float*>(in);
+}

--- a/HeterogeneousCore/SonicTriton/plugins/converters/Int64StandardConverter.cc
+++ b/HeterogeneousCore/SonicTriton/plugins/converters/Int64StandardConverter.cc
@@ -1,0 +1,20 @@
+#include "HeterogeneousCore/SonicTriton/interface/TritonConverterBase.h"
+
+class Int64StandardConverter : public TritonConverterBase<int64_t> {
+public:
+  Int64StandardConverter(const edm::ParameterSet& conf)
+      : TritonConverterBase<int64_t>(conf) {}
+
+  const uint8_t* convertIn(const int64_t* in) override;
+  const int64_t* convertOut(const uint8_t* in) override;
+};
+
+DEFINE_EDM_PLUGIN(TritonConverterFactory<int64_t>, Int64StandardConverter, "Int64StandardConverter");
+
+const uint8_t* Int64StandardConverter::convertIn(const int64_t *in) {
+    return reinterpret_cast<const uint8_t*>(in);
+}
+
+const int64_t* Int64StandardConverter::convertOut(const uint8_t* in) {
+    return reinterpret_cast<const int64_t*>(in);
+}

--- a/HeterogeneousCore/SonicTriton/plugins/converters/Int64StandardConverter.cc
+++ b/HeterogeneousCore/SonicTriton/plugins/converters/Int64StandardConverter.cc
@@ -2,8 +2,7 @@
 
 class Int64StandardConverter : public TritonConverterBase<int64_t> {
 public:
-  Int64StandardConverter(const edm::ParameterSet& conf)
-      : TritonConverterBase<int64_t>(conf) {}
+  Int64StandardConverter(const edm::ParameterSet& conf) : TritonConverterBase<int64_t>(conf) {}
 
   const uint8_t* convertIn(const int64_t* in) override;
   const int64_t* convertOut(const uint8_t* in) override;
@@ -11,10 +10,6 @@ public:
 
 DEFINE_EDM_PLUGIN(TritonConverterFactory<int64_t>, Int64StandardConverter, "Int64StandardConverter");
 
-const uint8_t* Int64StandardConverter::convertIn(const int64_t *in) {
-    return reinterpret_cast<const uint8_t*>(in);
-}
+const uint8_t* Int64StandardConverter::convertIn(const int64_t* in) { return reinterpret_cast<const uint8_t*>(in); }
 
-const int64_t* Int64StandardConverter::convertOut(const uint8_t* in) {
-    return reinterpret_cast<const int64_t*>(in);
-}
+const int64_t* Int64StandardConverter::convertOut(const uint8_t* in) { return reinterpret_cast<const int64_t*>(in); }

--- a/HeterogeneousCore/SonicTriton/src/TritonClient.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonClient.cc
@@ -79,7 +79,7 @@ TritonClient::TritonClient(const edm::ParameterSet& params)
   if (!msg_str.empty())
     throw cms::Exception("ModelErrors") << msg_str;
 
-  const edm::ParameterSet converterDefs = params.getParameterSet("converterDefinition");
+  const edm::ParameterSet& converterDefs = params.getParameterSet("converterDefinition");
   //setup input map
   std::stringstream io_msg;
   if (verbose_)

--- a/HeterogeneousCore/SonicTriton/src/TritonData.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonData.cc
@@ -104,15 +104,15 @@ void TritonData<IO>::setBatchSize(unsigned bsize) {
 }
 
 template <>
-template<typename DT>
+template <typename DT>
 std::unique_ptr<TritonConverterBase<DT>> TritonInputData::createConverter() const {
-  return TritonConverterFactory<DT>::get()->create(converterName_,converterConf_);
+  return TritonConverterFactory<DT>::get()->create(converterName_, converterConf_);
 }
 
 template <>
-template<typename DT>
+template <typename DT>
 std::unique_ptr<TritonConverterBase<DT>> TritonOutputData::createConverter() const {
-  return TritonConverterFactory<DT>::get()->create(converterName_,converterConf_);
+  return TritonConverterFactory<DT>::get()->create(converterName_, converterConf_);
 }
 
 //io accessors
@@ -130,7 +130,7 @@ void TritonInputData::toServer(std::shared_ptr<TritonInput<DT>> ptr) {
   //shape must be specified for variable dims or if batch size changes
   data_->SetShape(fullShape_);
 
-  std::unique_ptr<TritonConverterBase<DT>> converter = createConverter<DT>(); 
+  std::unique_ptr<TritonConverterBase<DT>> converter = createConverter<DT>();
 
   if (byteSize_ != converter->getByteSize())
     throw cms::Exception("TritonDataError") << name_ << " input(): inconsistent byte size " << converter->getByteSize()

--- a/HeterogeneousCore/SonicTriton/src/pluginFactories.cc
+++ b/HeterogeneousCore/SonicTriton/src/pluginFactories.cc
@@ -1,0 +1,4 @@
+#include "HeterogeneousCore/SonicTriton/interface/TritonConverterBase.h"
+
+EDM_REGISTER_PLUGINFACTORY(TritonConverterFactory<float>, "TritonConverterFloatFactory");
+EDM_REGISTER_PLUGINFACTORY(TritonConverterFactory<int64_t>, "TritonConverterInt64Factory");

--- a/HeterogeneousCore/SonicTriton/test/tritonTest_cfg.py
+++ b/HeterogeneousCore/SonicTriton/test/tritonTest_cfg.py
@@ -49,6 +49,9 @@ process.TritonProducer = cms.EDProducer(options.producer,
         modelVersion = cms.string(""),
         verbose = cms.untracked.bool(options.verbose),
         allowedTries = cms.untracked.uint32(0),
+        converterDefinition = cms.PSet(
+            converterName = cms.string("FloatStandardConverter"),
+        ),
     )
 )
 if options.producer=="TritonImageProducer":


### PR DESCRIPTION
This is a first attempt at implementing a convertor factory for transforming inputs from one data type to another, useful for running on different servers with different precision without recompile the main producer.

Converters are located in `HeterogeneousCore/SonicTriton/plugins/converters/`, and currently two trivial converters are included (FloatStandardConverter.cc and Int64StandardConverter.cc) for `float` and `int64_t` in addition to an example converter for `float` to `ap_fixed<16,6>` (FloatApFixed16Converter.cc).
