### PR TITLE
Initial Synch of SONIC Particle Net

### DIFF
--- a/PhysicsTools/PatAlgos/python/recoLayer0/bTagging_cff.py
+++ b/PhysicsTools/PatAlgos/python/recoLayer0/bTagging_cff.py
@@ -251,11 +251,11 @@ for disc in _pfMassDecorrelatedDeepBoostedJetTagsMetaDiscrs:
 
 # -----------------------------------
 # setup ParticleNet AK8
-from RecoBTag.ONNXRuntime.pfParticleNet_cff import _pfParticleNetJetTagsProbs, _pfParticleNetJetTagsMetaDiscrs, \
+from RecoBTag.ONNXRuntime.pfParticleNet_cff import _pfParticleNetJetTagsProbs, _pfParticleNetSonicJetTagsProbs, _pfParticleNetJetTagsMetaDiscrs, \
     _pfMassDecorrelatedParticleNetJetTagsProbs, _pfMassDecorrelatedParticleNetJetTagsMetaDiscrs, \
     _pfParticleNetMassRegressionOutputs
 # update supportedBtagDiscr
-for disc in _pfParticleNetJetTagsProbs + _pfMassDecorrelatedParticleNetJetTagsProbs + _pfParticleNetMassRegressionOutputs:
+for disc in _pfParticleNetJetTagsProbs + _pfParticleNetSonicJetTagsProbs + _pfMassDecorrelatedParticleNetJetTagsProbs + _pfParticleNetMassRegressionOutputs:
     supportedBtagDiscr[disc] = [["pfParticleNetTagInfos"]]
 # update supportedMetaDiscr
 for disc in _pfParticleNetJetTagsMetaDiscrs:

--- a/RecoBTag/FeatureTools/BuildFile.xml
+++ b/RecoBTag/FeatureTools/BuildFile.xml
@@ -4,6 +4,8 @@
 <use name="DataFormats/ParticleFlowCandidate"/>
 <use name="TrackingTools/IPTools"/>
 <use name="RecoBTag/TrackProbability"/>
+<use name="PhysicsTools/ONNXRuntime"/>
+<use name="json"/>
 <export>
   <lib name="1"/>
 </export>

--- a/RecoBTag/FeatureTools/interface/deep_helpers.h
+++ b/RecoBTag/FeatureTools/interface/deep_helpers.h
@@ -15,6 +15,17 @@
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
 
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "PhysicsTools/ONNXRuntime/interface/ONNXRuntime.h"
+
+#include <iostream>
+#include <fstream>
+#include <algorithm>
+#include <numeric>
+#include <nlohmann/json.hpp>
+
 namespace btagbtvdeep {
 
   // remove infs and NaNs with value  (adapted from DeepNTuples)
@@ -101,6 +112,26 @@ namespace btagbtvdeep {
 
     VarInfo info(const std::string &name) const { return var_info_map.at(name); }
   };
+
+  int center_norm_pad(const std::vector<float> &input,
+                      float center,
+                      float scale,
+                      unsigned min_length,
+                      unsigned max_length,
+                      std::vector<float> &datavec,
+                      int startval,
+                      float pad_value = 0,
+                      float replace_inf_value = 0,
+                      float min = 0,
+                      float max = -1);
+
+  void ParticleNetConstructor(const edm::ParameterSet &Config_,
+                              bool doExtra,
+                              std::vector<std::string> &input_names_,
+                              std::unordered_map<std::string, PreprocessParams> &prep_info_map_,
+                              std::vector<std::vector<int64_t>> &input_shapes_,
+                              std::vector<unsigned> &input_sizes_,
+                              cms::Ort::FloatArrays *data_);
 
 }  // namespace btagbtvdeep
 #endif  //RecoBTag_FeatureTools_deep_helpers_h

--- a/RecoBTag/FeatureTools/src/deep_helpers.cc
+++ b/RecoBTag/FeatureTools/src/deep_helpers.cc
@@ -2,6 +2,8 @@
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 #include "FWCore/Utilities/interface/isFinite.h"
 
+//#include <nlohmann/json.hpp>
+
 namespace btagbtvdeep {
 
   constexpr static int qualityMap[8] = {1, 0, 1, 1, 4, 4, 5, 6};
@@ -117,6 +119,109 @@ namespace btagbtvdeep {
     uint16_t qualityFlags = 0;
     qualityFlags = (qualityFlags & ~trackHighPurityMask) | ((highPurity << trackHighPurityShift) & trackHighPurityMask);
     return int16_t((qualityFlags & lostInnerHitsMask) >> lostInnerHitsShift) - 1;
+  }
+
+  int center_norm_pad(const std::vector<float> &input,
+                      float center,
+                      float norm_factor,
+                      unsigned min_length,
+                      unsigned max_length,
+                      std::vector<float> &datavec,
+                      int startval,
+                      float pad_value,
+                      float replace_inf_value,
+                      float min,
+                      float max) {
+    // do variable shifting/scaling/padding/clipping in one go
+
+    assert(min <= pad_value && pad_value <= max);
+    assert(min_length <= max_length);
+
+    unsigned target_length = std::clamp((unsigned)input.size(), min_length, max_length);
+    for (unsigned i = 0; i < target_length; ++i) {
+      if (i < input.size()) {
+        datavec[i + startval] = std::clamp((catch_infs(input[i], replace_inf_value) - center) * norm_factor, min, max);
+      } else {
+        datavec[i + startval] = pad_value;
+      }
+    }
+    return target_length;
+  }
+
+  void ParticleNetConstructor(const edm::ParameterSet &Config_,
+                              bool doExtra,
+                              std::vector<std::string> &input_names_,
+                              std::unordered_map<std::string, PreprocessParams> &prep_info_map_,
+                              std::vector<std::vector<int64_t>> &input_shapes_,
+                              std::vector<unsigned> &input_sizes_,
+                              cms::Ort::FloatArrays *data_) {
+    // load preprocessing info
+    auto json_path = Config_.getParameter<std::string>("preprocess_json");
+    if (!json_path.empty()) {
+      // use preprocessing json file if available
+      std::ifstream ifs(edm::FileInPath(json_path).fullPath());
+      nlohmann::json js = nlohmann::json::parse(ifs);
+      js.at("input_names").get_to(input_names_);
+      for (const auto &group_name : input_names_) {
+        const auto &group_pset = js.at(group_name);
+        auto &prep_params = prep_info_map_[group_name];
+        group_pset.at("var_names").get_to(prep_params.var_names);
+        if (group_pset.contains("var_length")) {
+          prep_params.min_length = group_pset.at("var_length");
+          prep_params.max_length = prep_params.min_length;
+        } else {
+          prep_params.min_length = group_pset.at("min_length");
+          prep_params.max_length = group_pset.at("max_length");
+          input_shapes_.push_back({1, (int64_t)prep_params.var_names.size(), -1});
+        }
+        const auto &var_info_pset = group_pset.at("var_infos");
+        for (const auto &var_name : prep_params.var_names) {
+          const auto &var_pset = var_info_pset.at(var_name);
+          double median = var_pset.at("median");
+          double norm_factor = var_pset.at("norm_factor");
+          double replace_inf_value = var_pset.at("replace_inf_value");
+          double lower_bound = var_pset.at("lower_bound");
+          double upper_bound = var_pset.at("upper_bound");
+          double pad = var_pset.contains("pad") ? double(var_pset.at("pad")) : 0;
+          prep_params.var_info_map[var_name] =
+              PreprocessParams::VarInfo(median, norm_factor, replace_inf_value, lower_bound, upper_bound, pad);
+        }
+
+        if (doExtra && data_ != nullptr) {
+          // create data storage with a fixed size vector initialized w/ 0
+          const auto &len = input_sizes_.emplace_back(prep_params.max_length * prep_params.var_names.size());
+          data_->emplace_back(len, 0);
+        }
+      }
+    } else {
+      // otherwise use the PSet in the python config file
+      const auto &prep_pset = Config_.getParameterSet("preprocessParams");
+      input_names_ = prep_pset.getParameter<std::vector<std::string>>("input_names");
+      for (const auto &group_name : input_names_) {
+        const edm::ParameterSet &group_pset = prep_pset.getParameterSet(group_name);
+        auto &prep_params = prep_info_map_[group_name];
+        prep_params.var_names = group_pset.getParameter<std::vector<std::string>>("var_names");
+        prep_params.min_length = group_pset.getParameter<unsigned>("var_length");
+        prep_params.max_length = prep_params.min_length;
+        const auto &var_info_pset = group_pset.getParameterSet("var_infos");
+        for (const auto &var_name : prep_params.var_names) {
+          const edm::ParameterSet &var_pset = var_info_pset.getParameterSet(var_name);
+          double median = var_pset.getParameter<double>("median");
+          double norm_factor = var_pset.getParameter<double>("norm_factor");
+          double replace_inf_value = var_pset.getParameter<double>("replace_inf_value");
+          double lower_bound = var_pset.getParameter<double>("lower_bound");
+          double upper_bound = var_pset.getParameter<double>("upper_bound");
+          prep_params.var_info_map[var_name] =
+              PreprocessParams::VarInfo(median, norm_factor, replace_inf_value, lower_bound, upper_bound, 0);
+        }
+
+        if (doExtra && data_ != nullptr) {
+          // create data storage with a fixed size vector initialized w/ 0
+          const auto &len = input_sizes_.emplace_back(prep_params.max_length * prep_params.var_names.size());
+          data_->emplace_back(len, 0);
+        }
+      }
+    }
   }
 
 }  // namespace btagbtvdeep

--- a/RecoBTag/ONNXRuntime/plugins/BuildFile.xml
+++ b/RecoBTag/ONNXRuntime/plugins/BuildFile.xml
@@ -5,5 +5,6 @@
   <use name="PhysicsTools/ONNXRuntime"/>
   <use name="RecoBTag/FeatureTools"/>
   <use name="RecoBTag/ONNXRuntime"/>
+  <use name="HeterogeneousCore/SonicTriton"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/RecoBTag/ONNXRuntime/python/pfParticleNet_cff.py
+++ b/RecoBTag/ONNXRuntime/python/pfParticleNet_cff.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoBTag.FeatureTools.pfDeepBoostedJetTagInfos_cfi import pfDeepBoostedJetTagInfos
 from RecoBTag.ONNXRuntime.boostedJetONNXJetTagsProducer_cfi import boostedJetONNXJetTagsProducer
+from RecoBTag.ONNXRuntime.particleNetSonicJetTagsProducer_cfi import particleNetSonicJetTagsProducer
 from RecoBTag.ONNXRuntime.pfParticleNetDiscriminatorsJetTags_cfi import pfParticleNetDiscriminatorsJetTags
 from RecoBTag.ONNXRuntime.pfMassDecorrelatedParticleNetDiscriminatorsJetTags_cfi import pfMassDecorrelatedParticleNetDiscriminatorsJetTags
 
@@ -11,8 +12,27 @@ pfParticleNetTagInfos = pfDeepBoostedJetTagInfos.clone(
 
 pfParticleNetJetTags = boostedJetONNXJetTagsProducer.clone(
     src = 'pfParticleNetTagInfos',
-    preprocess_json = 'RecoBTag/Combined/data/ParticleNetAK8/General/V01/preprocess.json',
+    preprocess_json = 'RecoBTag/Combined/data/ParticleNetAK8/General/V01/preprocess_noragged.json',
+    #preprocess_json = 'RecoBTag/Combined/data/ParticleNetAK8/General/V01/preprocess.json',
     model_path = 'RecoBTag/Combined/data/ParticleNetAK8/General/V01/particle-net.onnx',
+    flav_names = ["probTbcq",  "probTbqq",  "probTbc",   "probTbq",  "probTbel", "probTbmu", "probTbta",
+                  "probWcq",   "probWqq",   "probZbb",   "probZcc",  "probZqq",  "probHbb", "probHcc",
+                  "probHqqqq", "probQCDbb", "probQCDcc", "probQCDb", "probQCDc", "probQCDothers"],
+)
+
+pfParticleNetSonicJetTags = particleNetSonicJetTagsProducer.clone(
+    src = 'pfParticleNetTagInfos',
+    preprocess_json = 'RecoBTag/Combined/data/ParticleNetAK8/General/V01/preprocess_noragged.json',
+    #preprocess_json = 'RecoBTag/Combined/data/ParticleNetAK8/General/V01/preprocess.json',
+    Client = cms.PSet(
+        timeout = cms.untracked.uint32(300),
+        modelName = cms.string("particlenet"),
+        mode = cms.string("Async"),
+        modelConfigPath = cms.FileInPath("HeterogeneousCore/SonicTriton/data/models/particlenet/config.pbtxt"),
+        modelVersion = cms.string(""),
+        verbose = cms.untracked.bool(False),
+        allowedTries = cms.untracked.uint32(0),
+    ),
     flav_names = ["probTbcq",  "probTbqq",  "probTbc",   "probTbq",  "probTbel", "probTbmu", "probTbta",
                   "probWcq",   "probWqq",   "probZbb",   "probZcc",  "probZqq",  "probHbb", "probHcc",
                   "probHqqqq", "probQCDbb", "probQCDcc", "probQCDb", "probQCDc", "probQCDothers"],
@@ -45,6 +65,9 @@ pfParticleNetTask = cms.Task(puppi, primaryVertexAssociation, pfParticleNetTagIn
 # nominal: probs
 _pfParticleNetJetTagsProbs = ['pfParticleNetJetTags:' + flav_name
                               for flav_name in pfParticleNetJetTags.flav_names]
+
+_pfParticleNetSonicJetTagsProbs  = ['pfParticleNetSonicJetTags:' + flav_name
+                                    for flav_name in pfParticleNetJetTags.flav_names]
 # nominal: meta-taggers
 _pfParticleNetJetTagsMetaDiscrs = ['pfParticleNetDiscriminatorsJetTags:' + disc.name.value()
                                    for disc in pfParticleNetDiscriminatorsJetTags.discriminators]

--- a/RecoBTag/ONNXRuntime/test/plot_particle_net.py
+++ b/RecoBTag/ONNXRuntime/test/plot_particle_net.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+import ROOT as rt
+from DataFormats.FWLite import Events,Handle
+import itertools as it
+from ROOT import btagbtvdeep
+import pandas as pd
+import numpy as np
+import matplotlib.pyplot as plt
+
+# file evaluated with DeepJet framework
+# jets redone from AOD using CMSSW TF modules
+#cmssw_miniaod = "test_particle_net_MINIAODSIM.root"
+cmssw_miniaod = "test_particle_net_MINIAODSIM_noragged.root"
+
+jetsLabel = "selectedUpdatedPatJets"
+
+from RecoBTag.ONNXRuntime.pfParticleNet_cff import _pfParticleNetJetTagsProbs
+from RecoBTag.ONNXRuntime.pfParticleNet_cff import _pfParticleNetSonicJetTagsProbs
+disc_names = _pfParticleNetJetTagsProbs+_pfParticleNetSonicJetTagsProbs
+
+jet_pt = "fj_pt"
+jet_eta = "fj_eta"
+
+c_numbers = ['event_n']
+
+c_cmssw = { d_name : []  for d_name in disc_names + [jet_pt, jet_eta] + c_numbers }
+jetsHandle = Handle("std::vector<pat::Jet>")
+cmssw_evs = Events(cmssw_miniaod)
+
+max_n_jets = 1000000
+max_n_events = 500000
+n_jets = 0
+
+for i, ev in enumerate(cmssw_evs):
+    event_number = ev.object().id().event()
+    if (n_jets >= max_n_jets): break
+    ev.getByLabel(jetsLabel, jetsHandle)
+    jets = jetsHandle.product()
+    for i_j,j in enumerate(jets):
+        uncorr = j.jecFactor("Uncorrected")
+        ptRaw = j.pt()*uncorr
+        if ptRaw < 200.0 or abs(j.eta()) > 2.4: continue
+        if (n_jets >= max_n_jets): break
+        c_cmssw["event_n"].append(event_number)
+        c_cmssw[jet_pt].append(ptRaw)
+        c_cmssw[jet_eta].append(j.eta())
+        discs = j.getPairDiscri()
+        for d in discs:
+            if d.first in disc_names:
+                c_cmssw[d.first].append(d.second)
+        n_jets +=1
+        
+df_cmssw = pd.DataFrame(c_cmssw)
+df_cmssw.sort_values(['event_n', jet_pt], ascending=[True, False], inplace=True)
+df_cmssw.reset_index(drop=True)
+print(df_cmssw[['event_n','fj_eta','fj_pt',
+                'pfParticleNetJetTags:probTbq','pfParticleNetSonicJetTags:probTbq',
+            ]])
+
+n_bins = 50
+
+print('number of tags', len(disc_names))
+fig, axs = plt.subplots(5,4,figsize=(50,40))
+for i,ax in enumerate(axs.flatten()):
+    cmssw_col = disc_names[i]
+    ax.hist(df_cmssw[cmssw_col], bins=np.linspace(np.amin(df_cmssw[cmssw_col]), np.amax(df_cmssw[cmssw_col]), n_bins))
+    ax.set_yscale('log')
+    ax.set_ylim(0.5, 1000)
+    ax.set_xlim(0, 1)
+    ax.set_xlabel(cmssw_col)
+    ax.set_ylabel('Jets')
+#fig.savefig('particle_net_hist.png')
+fig.savefig('particle_net_hist_noragged.png')


### PR DESCRIPTION
#### PR description:

Synch of development Javier worked on to implement particle net algorithm in SONIC.  Includes data from Javier's branch: https://github.com/jmduarte/RecoBTag-Combined, which is needed to run the algorithm, when following the gist: https://gist.github.com/jmduarte/e82cb02d4d8a64f861c0ab229b38ccff.  This introduces several MB into the cmssw codebase, so I'm not sure if we want to include it - though it would reduce the number of steps needed to run out of the box.

Many thanks to Yongbin's README: https://github.com/yongbinfeng/cmssw/blob/SonicProduction/RecoMET/METPUSubtraction/test/readme.md

#### PR validation:

The code runs per the gist linked above on FNAL's ailab01 node.  I ran over a local copy of /store/mc/RunIIFall17MiniAODv2/TTToHadronic_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/90000/DCFE3F5F-AE42-E811-B6DB-008CFAF72A64.root (the path to the local copy can be found in the test_particle_net_cfg.py macro).
