### PR TITLE
Adding pseudo-ragged batching to particlenet

### DIFF
--- a/RecoBTag/FeatureTools/interface/deep_helpers.h
+++ b/RecoBTag/FeatureTools/interface/deep_helpers.h
@@ -125,6 +125,17 @@ namespace btagbtvdeep {
                       float min = 0,
                       float max = -1);
 
+  int center_norm_pad_halfRagged(const std::vector<float> &input,
+                      float center,
+                      float scale,
+                      unsigned target_length,
+                      std::vector<float> &datavec,
+                      int startval,
+                      float pad_value = 0,
+                      float replace_inf_value = 0,
+                      float min = 0,
+                      float max = -1);
+
   void ParticleNetConstructor(const edm::ParameterSet &Config_,
                               bool doExtra,
                               std::vector<std::string> &input_names_,

--- a/RecoBTag/FeatureTools/src/deep_helpers.cc
+++ b/RecoBTag/FeatureTools/src/deep_helpers.cc
@@ -148,6 +148,30 @@ namespace btagbtvdeep {
     return target_length;
   }
 
+  int center_norm_pad_halfRagged(const std::vector<float> &input,
+                      float center,
+                      float norm_factor,
+                      unsigned target_length,
+                      std::vector<float> &datavec,
+                      int startval,
+                      float pad_value,
+                      float replace_inf_value,
+                      float min,
+                      float max) {
+    // do variable shifting/scaling/padding/clipping in one go
+
+    assert(min <= pad_value && pad_value <= max);
+
+    for (unsigned i = 0; i < target_length; ++i) {
+      if (i < input.size()) {
+        datavec[i + startval] = std::clamp((catch_infs(input[i], replace_inf_value) - center) * norm_factor, min, max);
+      } else {
+        datavec[i + startval] = pad_value;
+      }
+    }
+    return target_length;
+  }
+
   void ParticleNetConstructor(const edm::ParameterSet &Config_,
                               bool doExtra,
                               std::vector<std::string> &input_names_,

--- a/RecoBTag/ONNXRuntime/python/pfParticleNetAK4_cff.py
+++ b/RecoBTag/ONNXRuntime/python/pfParticleNetAK4_cff.py
@@ -22,7 +22,7 @@ pfParticleNetAK4JetTags = boostedJetONNXJetTagsProducer.clone(
 
 particleNetSonicTriton.toReplaceWith(pfParticleNetAK4JetTags, _particleNetSonicJetTagsProducer.clone(
     src = 'pfParticleNetAK4TagInfos',
-    preprocess_json = 'RecoBTag/Combined/data/ParticleNetAK4/CHS/V00/preprocess_noragged.json',
+    preprocess_json = 'RecoBTag/Combined/data/ParticleNetAK4/CHS/V00/preprocess.json',
     Client = cms.PSet(
         timeout = cms.untracked.uint32(300),
         mode = cms.string("Async"),

--- a/RecoBTag/ONNXRuntime/python/pfParticleNet_cff.py
+++ b/RecoBTag/ONNXRuntime/python/pfParticleNet_cff.py
@@ -22,7 +22,7 @@ pfParticleNetJetTags = boostedJetONNXJetTagsProducer.clone(
 
 particleNetSonicTriton.toReplaceWith(pfParticleNetJetTags, _particleNetSonicJetTagsProducer.clone(
     src = 'pfParticleNetTagInfos',
-    preprocess_json = 'RecoBTag/Combined/data/ParticleNetAK8/General/V01/preprocess_noragged.json',
+    preprocess_json = 'RecoBTag/Combined/data/ParticleNetAK8/General/V01/preprocess.json',
     Client = cms.PSet(
         timeout = cms.untracked.uint32(300),
         mode = cms.string("Async"),
@@ -47,7 +47,7 @@ pfMassDecorrelatedParticleNetJetTags = boostedJetONNXJetTagsProducer.clone(
 
 particleNetSonicTriton.toReplaceWith(pfMassDecorrelatedParticleNetJetTags, _particleNetSonicJetTagsProducer.clone(
     src = 'pfParticleNetTagInfos',
-    preprocess_json = 'RecoBTag/Combined/data/ParticleNetAK8/MD-2prong/V01/preprocess_noragged.json',
+    preprocess_json = 'RecoBTag/Combined/data/ParticleNetAK8/MD-2prong/V01/preprocess.json',
     Client = cms.PSet(
         timeout = cms.untracked.uint32(300),
         modelName = cms.string("particlenet_AK8_MD-2prong"),
@@ -69,7 +69,7 @@ pfParticleNetMassRegressionJetTags = boostedJetONNXJetTagsProducer.clone(
 
 particleNetSonicTriton.toReplaceWith(pfParticleNetMassRegressionJetTags, _particleNetSonicJetTagsProducer.clone(
     src = 'pfParticleNetTagInfos',
-    preprocess_json = 'RecoBTag/Combined/data/ParticleNetAK8/MassRegression/V01/preprocess_noragged.json',
+    preprocess_json = 'RecoBTag/Combined/data/ParticleNetAK8/MassRegression/V01/preprocess.json',
     Client = cms.PSet(
         timeout = cms.untracked.uint32(300),
         modelName = cms.string("particlenet_AK8_MassRegression"),


### PR DESCRIPTION
#### PR description:

This PR adds pseudo-ragged batching for particle net.  MUST be combined with changes in https://github.com/fastmachinelearning/sonic-models/pull/6, where PN input dimensions are made variable

#### PR validation:

Performed local tests similar to those performed when developing sonic PN.  I compared non-sonic tags to sonic tags for a ttbar sample, and the results matched
