### PR TITLE
fixing center_norm_pad_halfRagged

### DIFF
--- a/RecoBTag/FeatureTools/src/deep_helpers.cc
+++ b/RecoBTag/FeatureTools/src/deep_helpers.cc
@@ -162,11 +162,17 @@ namespace btagbtvdeep {
 
     assert(min <= pad_value && pad_value <= max);
 
-    for (unsigned i = 0; i < input.size(); ++i) {
-      datavec.push_back(std::clamp((catch_infs(input[i], replace_inf_value) - center) * norm_factor, min, max));
+    if (input.size() <= target_length) {
+      for (unsigned i = 0; i < input.size(); ++i) {
+        datavec.push_back(std::clamp((catch_infs(input[i], replace_inf_value) - center) * norm_factor, min, max));
+      }
+      if (input.size() < target_length)
+        datavec.insert(datavec.end(), target_length - input.size(), pad_value);
+    } else {
+      for (unsigned i = 0; i < target_length; ++i) {
+        datavec.push_back(std::clamp((catch_infs(input[i], replace_inf_value) - center) * norm_factor, min, max));
+      }
     }
-    datavec.insert(datavec.end(), target_length - input.size(), pad_value);
-
     return target_length;
   }
 

--- a/RecoBTag/FeatureTools/src/deep_helpers.cc
+++ b/RecoBTag/FeatureTools/src/deep_helpers.cc
@@ -162,17 +162,12 @@ namespace btagbtvdeep {
 
     assert(min <= pad_value && pad_value <= max);
 
-    if (input.size() <= target_length) {
-      for (unsigned i = 0; i < input.size(); ++i) {
-        datavec.push_back(std::clamp((catch_infs(input[i], replace_inf_value) - center) * norm_factor, min, max));
-      }
-      if (input.size() < target_length)
-        datavec.insert(datavec.end(), target_length - input.size(), pad_value);
-    } else {
-      for (unsigned i = 0; i < target_length; ++i) {
-        datavec.push_back(std::clamp((catch_infs(input[i], replace_inf_value) - center) * norm_factor, min, max));
-      }
+    for (unsigned i = 0; i < std::min(static_cast<unsigned int>(input.size()), target_length); ++i) {
+      datavec.push_back(std::clamp((catch_infs(input[i], replace_inf_value) - center) * norm_factor, min, max));
     }
+    if (input.size() < target_length)
+      datavec.insert(datavec.end(), target_length - input.size(), pad_value);
+
     return target_length;
   }
 


### PR DESCRIPTION
#### PR description:

Protecting center_norm_pad_halfRagged in the case that the are more particles in the jet than the max allowed in the triton server version of the model.  E.g. Chun-Yu was running into some events where AK4 jets had more than 50 particles, which is the max input for ParticleNetAK4.

#### PR validation:

I ran over 200 events of the step2_PAT workflow using an ailab server.  This finished successfully.
