### PR TITLE
Add retry mechanism and dynamic model loading to SONIC framework

### DIFF
--- a/HeterogeneousCore/SonicCore/BuildFile.xml
+++ b/HeterogeneousCore/SonicCore/BuildFile.xml
@@ -2,6 +2,7 @@
 <use name="FWCore/Concurrency"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>
+<use name="FWCore/PluginManager"/>
 <use name="FWCore/Utilities"/>
 <export>
   <lib name="1"/>

--- a/HeterogeneousCore/SonicCore/interface/RetryActionBase.h
+++ b/HeterogeneousCore/SonicCore/interface/RetryActionBase.h
@@ -1,0 +1,36 @@
+#ifndef HeterogeneousCore_SonicCore_RetryActionBase
+#define HeterogeneousCore_SonicCore_RetryActionBase
+
+#include "FWCore/PluginManager/interface/PluginFactory.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "HeterogeneousCore/SonicCore/interface/SonicClientBase.h"
+#include <memory>
+#include <string>
+
+// Base class for retry actions
+class RetryActionBase {
+public:
+  RetryActionBase(const edm::ParameterSet& conf, SonicClientBase* client);
+  virtual ~RetryActionBase() = default;
+
+  bool shouldRetry() const { return shouldRetry_; }  // Getter for shouldRetry_
+
+  virtual void retry() = 0;  // Pure virtual function for execution logic
+  virtual void start() = 0;  // Pure virtual function for execution logic for initialization
+
+protected:
+  void eval();                // interface for calling evaluate in client
+  void finish(bool success);  // interface for calling finish directly in client
+
+protected:
+  SonicClientBase* client_;
+  bool shouldRetry_;  // Flag to track if further retries should happen
+};
+
+// Define the factory for creating retry actions
+using RetryActionFactory =
+    edmplugin::PluginFactory<RetryActionBase*(const edm::ParameterSet&, SonicClientBase* client)>;
+
+#endif
+
+#define DEFINE_RETRY_ACTION(type) DEFINE_EDM_PLUGIN(RetryActionFactory, type, #type);

--- a/HeterogeneousCore/SonicCore/plugins/BuildFile.xml
+++ b/HeterogeneousCore/SonicCore/plugins/BuildFile.xml
@@ -1,0 +1,6 @@
+<use name="FWCore/Framework"/>
+<use name="FWCore/PluginManager"/>
+<use name="FWCore/ParameterSet"/>
+<use name="HeterogeneousCore/SonicCore"/>
+<plugin file="*.cc" name="pluginHeterogeneousCoreSonicCore"/>
+

--- a/HeterogeneousCore/SonicCore/plugins/RetrySameServerAction.cc
+++ b/HeterogeneousCore/SonicCore/plugins/RetrySameServerAction.cc
@@ -1,0 +1,28 @@
+#include "HeterogeneousCore/SonicCore/interface/RetryActionBase.h"
+#include "HeterogeneousCore/SonicCore/interface/SonicClientBase.h"
+
+class RetrySameServerAction : public RetryActionBase {
+public:
+  RetrySameServerAction(const edm::ParameterSet& pset, SonicClientBase* client)
+      : RetryActionBase(pset, client), allowedTries_(pset.getUntrackedParameter<unsigned>("allowedTries", 0)) {}
+
+  void start() override { tries_ = 0; };
+
+protected:
+  void retry() override;
+
+private:
+  unsigned allowedTries_, tries_;
+};
+
+void RetrySameServerAction::retry() {
+  ++tries_;
+  //if max retries has not been exceeded, call evaluate again
+  if (tries_ >= allowedTries_) {
+    shouldRetry_ = false;  // Flip flag when max retries are reached
+    edm::LogInfo("RetrySameServerAction") << "Max retry attempts reached. No further retries.";
+  }
+  eval();
+}
+
+DEFINE_RETRY_ACTION(RetrySameServerAction)

--- a/HeterogeneousCore/SonicCore/src/RetryActionBase.cc
+++ b/HeterogeneousCore/SonicCore/src/RetryActionBase.cc
@@ -1,0 +1,15 @@
+#include "HeterogeneousCore/SonicCore/interface/RetryActionBase.h"
+
+// Constructor implementation
+RetryActionBase::RetryActionBase(const edm::ParameterSet& conf, SonicClientBase* client)
+    : client_(client), shouldRetry_(true) {
+  if (client_ == nullptr) {
+    throw cms::Exception("RetryActionBase") << "client pointer cannot be null";
+  }
+}
+
+void RetryActionBase::eval() { client_->evaluate(); }
+
+void RetryActionBase::finish(bool success) { client_->finish(success); }
+
+EDM_REGISTER_PLUGINFACTORY(RetryActionFactory, "RetryActionFactory");

--- a/HeterogeneousCore/SonicCore/src/SonicClientBase.cc
+++ b/HeterogeneousCore/SonicCore/src/SonicClientBase.cc
@@ -1,18 +1,34 @@
 #include "HeterogeneousCore/SonicCore/interface/SonicClientBase.h"
+#include "HeterogeneousCore/SonicCore/interface/RetryActionBase.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/ParameterSet/interface/allowedValues.h"
+
+// Custom deleter implementation
+void SonicClientBase::RetryDeleter::operator()(RetryActionBase* ptr) const { delete ptr; }
 
 SonicClientBase::SonicClientBase(const edm::ParameterSet& params,
                                  const std::string& debugName,
                                  const std::string& clientName)
-    : allowedTries_(params.getUntrackedParameter<unsigned>("allowedTries", 0)),
-      debugName_(debugName),
-      clientName_(clientName),
-      fullDebugName_(debugName_) {
+    : debugName_(debugName), clientName_(clientName), fullDebugName_(debugName_) {
   if (!clientName_.empty())
     fullDebugName_ += ":" + clientName_;
 
+  const auto& retryPSetList = params.getParameter<std::vector<edm::ParameterSet>>("Retry");
   std::string modeName(params.getParameter<std::string>("mode"));
+
+  for (const auto& retryPSet : retryPSetList) {
+    const std::string& actionType = retryPSet.getParameter<std::string>("retryType");
+
+    auto retryAction = RetryActionFactory::get()->create(actionType, retryPSet, this);
+    if (retryAction) {
+      //Convert to  RetryActionPtr Type from raw pointer of retryAction
+      retryActions_.emplace_back(RetryActionPtr(retryAction.release()));
+    } else {
+      throw cms::Exception("Configuration")
+          << "Unknown Retry type " << actionType << " for SonicClient: " << fullDebugName_;
+    }
+  }
+
   if (modeName == "Sync")
     setMode(SonicMode::Sync);
   else if (modeName == "Async")
@@ -40,24 +56,34 @@ void SonicClientBase::start(edm::WaitingTaskWithArenaHolder holder) {
   holder_ = std::move(holder);
 }
 
-void SonicClientBase::start() { tries_ = 0; }
+void SonicClientBase::start() {
+  totalTries_ = 0;
+  // initialize all actions
+  for (auto& action : retryActions_) {
+    action->start();
+  }
+}
 
 void SonicClientBase::finish(bool success, std::exception_ptr eptr) {
   //retries are only allowed if no exception was raised
   if (!success and !eptr) {
-    ++tries_;
-    //if max retries has not been exceeded, call evaluate again
-    if (tries_ < allowedTries_) {
-      evaluate();
-      //avoid calling doneWaiting() twice
-      return;
+    ++totalTries_;
+    edm::LogInfo("SonicClientBase") << "finish: failed after total tries of " << totalTries_;
+    for (const auto& action : retryActions_) {
+      if (action->shouldRetry()) {
+        edm::LogInfo("SonicClientBase") << "Calling retry()";
+        // retry() must trigger eval() or finish()
+        action->retry();
+        // return because another finish() was already called inside client->evaluate()
+        return;
+      }
     }
-    //prepare an exception if exceeded
-    else {
-      edm::Exception ex(edm::errors::ExternalFailure);
-      ex << "SonicCallFailed: call failed after max " << tries_ << " tries";
-      eptr = make_exception_ptr(ex);
-    }
+    //prepare an exception if no more retry actions left
+    edm::LogInfo("SonicClientBase") << "SonicCallFailed: call failed, no retry actions available after " << totalTries_
+                                    << " tries.";
+    edm::Exception ex(edm::errors::ExternalFailure);
+    ex << "SonicCallFailed: call failed, no retry actions available after " << totalTries_ << " tries.";
+    eptr = make_exception_ptr(ex);
   }
   if (holder_) {
     holder_->doneWaiting(eptr);
@@ -74,7 +100,20 @@ void SonicClientBase::fillBasePSetDescription(edm::ParameterSetDescription& desc
   //restrict allowed values
   desc.ifValue(edm::ParameterDescription<std::string>("mode", "PseudoAsync", true),
                edm::allowedValues<std::string>("Sync", "Async", "PseudoAsync"));
-  if (allowRetry)
-    desc.addUntracked<unsigned>("allowedTries", 0);
+  if (allowRetry) {
+    // Defines the structure of each entry in the VPSet
+    edm::ParameterSetDescription retryDesc;
+    retryDesc.add<std::string>("retryType", "RetrySameServerAction");
+    retryDesc.addUntracked<unsigned>("allowedTries", 0);
+
+    // Define a default retry action
+    edm::ParameterSet defaultRetry;
+    defaultRetry.addParameter<std::string>("retryType", "RetrySameServerAction");
+    defaultRetry.addUntrackedParameter<unsigned>("allowedTries", 0);
+
+    // Add the VPSet with the default retry action
+    desc.addVPSet("Retry", retryDesc, {defaultRetry});
+  }
+  desc.add("sonicClientBase", desc);
   desc.addUntracked<bool>("verbose", false);
 }

--- a/HeterogeneousCore/SonicCore/test/DummyClient.h
+++ b/HeterogeneousCore/SonicCore/test/DummyClient.h
@@ -36,7 +36,7 @@ protected:
     this->output_ = this->input_ * factor_;
 
     //simulate a failure
-    if (this->tries_ < fails_)
+    if (this->totalTries_ < fails_)
       this->finish(false);
     else
       this->finish(true);

--- a/HeterogeneousCore/SonicCore/test/sonicTestAna_cfg.py
+++ b/HeterogeneousCore/SonicCore/test/sonicTestAna_cfg.py
@@ -16,16 +16,27 @@ process.dummySyncAna = cms.EDAnalyzer("SonicDummyOneAnalyzer",
         mode = cms.string("Sync"),
         factor = cms.int32(-1),
         wait = cms.int32(10),
-        allowedTries = cms.untracked.uint32(0),
         fails = cms.uint32(0),
+        Retry = cms.VPSet(
+          cms.PSet(
+            retryType = cms.string('RetrySameServerAction'),
+            allowedTries = cms.untracked.uint32(0),
+          )
+        )
     ),
 )
 
 process.dummySyncAnaRetry = process.dummySyncAna.clone(
     Client = dict(
         wait = 2,
-        allowedTries = 2,
         fails = 1,
+        Retry = cms.VPSet(
+          cms.PSet(
+            retryType = cms.string('RetrySameServerAction'),
+            allowedTries = cms.untracked.uint32(2),
+          )
+        )
+
     )
 )
 

--- a/HeterogeneousCore/SonicCore/test/sonicTest_cfg.py
+++ b/HeterogeneousCore/SonicCore/test/sonicTest_cfg.py
@@ -17,15 +17,19 @@ process.maxEvents.input = 1
 
 process.options.numberOfThreads = 2
 process.options.numberOfStreams = 0
-
 process.dummySync = _moduleClass(_moduleName,
     input = cms.int32(1),
     Client = cms.PSet(
         mode = cms.string("Sync"),
         factor = cms.int32(-1),
         wait = cms.int32(10),
-        allowedTries = cms.untracked.uint32(0),
         fails = cms.uint32(0),
+        Retry = cms.VPSet(
+          cms.PSet(
+            retryType = cms.string('RetrySameServerAction'),
+            allowedTries = cms.untracked.uint32(0)
+          )
+        )
     ),
 )
 
@@ -35,8 +39,14 @@ process.dummyPseudoAsync = _moduleClass(_moduleName,
         mode = cms.string("PseudoAsync"),
         factor = cms.int32(2),
         wait = cms.int32(10),
-        allowedTries = cms.untracked.uint32(0),
         fails = cms.uint32(0),
+        Retry = cms.VPSet(
+          cms.PSet(
+            retryType = cms.string('RetrySameServerAction'),
+            allowedTries = cms.untracked.uint32(0)
+          )
+        )
+
     ),
 )
 
@@ -46,32 +56,53 @@ process.dummyAsync = _moduleClass(_moduleName,
         mode = cms.string("Async"),
         factor = cms.int32(5),
         wait = cms.int32(10),
-        allowedTries = cms.untracked.uint32(0),
         fails = cms.uint32(0),
+        Retry = cms.VPSet(
+          cms.PSet(
+            retryType = cms.string('RetrySameServerAction'),
+            allowedTries = cms.untracked.uint32(0)
+          )
+        )
     ),
 )
 
 process.dummySyncRetry = process.dummySync.clone(
     Client = dict(
         wait = 2,
-        allowedTries = 2,
         fails = 1,
+        Retry = cms.VPSet(
+          cms.PSet(
+            retryType = cms.string('RetrySameServerAction'),
+            allowedTries = cms.untracked.uint32(2)
+          )
+        )
+
     )
 )
 
 process.dummyPseudoAsyncRetry = process.dummyPseudoAsync.clone(
     Client = dict(
         wait = 2,
-        allowedTries = 2,
         fails = 1,
+        Retry = cms.VPSet(
+          cms.PSet(
+            retryType = cms.string('RetrySameServerAction'),
+            allowedTries = cms.untracked.uint32(2)
+          )
+        )
     )
 )
 
 process.dummyAsyncRetry = process.dummyAsync.clone(
     Client = dict(
         wait = 2,
-        allowedTries = 2,
         fails = 1,
+        Retry = cms.VPSet(
+          cms.PSet(
+            allowedTries = cms.untracked.uint32(2),
+            retryType = cms.string('RetrySameServerAction')
+          )
+        )
     )
 )
 

--- a/HeterogeneousCore/SonicTriton/BuildFile.xml
+++ b/HeterogeneousCore/SonicTriton/BuildFile.xml
@@ -10,6 +10,7 @@
 <iftool name="cuda">
   <use name="cuda"/>
 </iftool>
+
 <export>
-  <lib   name="1"/>
+  <lib name="1"/>
 </export>

--- a/HeterogeneousCore/SonicTriton/interface/RetryActionDiffServer.h
+++ b/HeterogeneousCore/SonicTriton/interface/RetryActionDiffServer.h
@@ -1,0 +1,32 @@
+#ifndef HeterogeneousCore_SonicTriton_RetryActionDiffServer_h
+#define HeterogeneousCore_SonicTriton_RetryActionDiffServer_h
+
+#include "HeterogeneousCore/SonicCore/interface/RetryActionBase.h"
+
+/**
+ * @class RetryActionDiffServer
+ * @brief A concrete implementation of RetryActionBase that attempts to retry an inference
+ * request on a different Triton server.
+ *
+ * This class provides a fallback mechanism. If an initial inference request fails
+ * (e.g., due to server unavailability or a model-specific error), this action will be
+ * triggered. It queries the central TritonService to select an alternative server (e.g.,
+ * the fallback server when available) and instructs the TritonClient to reconnect to
+ * that server for the retry attempt. This action is designed for one-time use per
+ * inference call; after the retry attempt, it disables itself until the next `start()`
+ * call.
+ */
+
+class RetryActionDiffServer : public RetryActionBase {
+public:
+  RetryActionDiffServer(const edm::ParameterSet& conf, SonicClientBase* client);
+  ~RetryActionDiffServer() override = default;
+
+  void retry() override;
+  void start() override;
+
+private:
+  unsigned tries_;
+};
+
+#endif

--- a/HeterogeneousCore/SonicTriton/interface/RetryFallbackServerAction.h
+++ b/HeterogeneousCore/SonicTriton/interface/RetryFallbackServerAction.h
@@ -1,0 +1,18 @@
+#ifndef HeterogeneousCore_SonicTriton_RetryFallbackServerAction_h
+#define HeterogeneousCore_SonicTriton_RetryFallbackServerAction_h
+
+#include "HeterogeneousCore/SonicCore/interface/RetryActionBase.h"
+
+class RetryFallbackServerAction : public RetryActionBase {
+public:
+  RetryFallbackServerAction(const edm::ParameterSet& conf, SonicClientBase* client);
+  ~RetryFallbackServerAction() override = default;
+
+  void retry() override;
+  void start() override;
+
+private:
+  unsigned tries_;
+};
+
+#endif

--- a/HeterogeneousCore/SonicTriton/interface/TritonClient.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonClient.h
@@ -3,11 +3,13 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Concurrency/interface/WaitingTaskWithArenaHolder.h"
 #include "FWCore/ServiceRegistry/interface/ServiceToken.h"
 #include "HeterogeneousCore/SonicCore/interface/SonicClient.h"
 #include "HeterogeneousCore/SonicTriton/interface/TritonData.h"
 #include "HeterogeneousCore/SonicTriton/interface/TritonService.h"
 
+#include <atomic>
 #include <map>
 #include <vector>
 #include <string>
@@ -52,11 +54,19 @@ public:
   bool isLocal() const { return isLocal_; }
   const TritonService* service() const;
   const TritonService* localService() const;
+  std::string modelName() const { return options_[0].model_name_; }
+  std::string serverName() const { return serverName_; }
+  virtual void connectToServer(const std::string& url);
+  virtual void updateServer(const std::string& serverName);
+  virtual void switchToFallback();
 
   //for fillDescriptions
   static void fillPSetDescription(edm::ParameterSetDescription& iDesc);
 
 protected:
+  // Protected default constructor for unit testing (no framework services)
+  TritonClient();
+
   //helpers
   bool noOuterDim() const { return noOuterDim_; }
   unsigned outerDim() const { return outerDim_; }
@@ -65,6 +75,8 @@ protected:
   void evaluate() override;
   template <typename F>
   bool handle_exception(F&& call);
+  template <typename F>
+  bool handle_exception_holder(edm::WaitingTaskWithArenaHolder& fh, F&& call);
 
   void reportServerSideStats(const ServerSideStats& stats) const;
   ServerSideStats summarizeServerStats(const inference::ModelStatistics& start_status,
@@ -83,6 +95,7 @@ protected:
   bool useSharedMemory_;
   TritonServerType serverType_;
   bool isLocal_;
+  std::string serverName_;
   grpc_compression_algorithm compressionAlgo_;
   triton::client::Headers headers_;
 
@@ -90,6 +103,7 @@ protected:
   //stores timeout, model name and version
   std::vector<triton::client::InferOptions> options_;
   edm::ServiceToken token_;
+  std::atomic<bool> inferSuccess_{true};
 
 private:
   friend TritonInputData;

--- a/HeterogeneousCore/SonicTriton/interface/TritonService.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonService.h
@@ -3,6 +3,7 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/GlobalIdentifier.h"
+#include "oneapi/tbb/concurrent_hash_map.h"
 
 #include <vector>
 #include <unordered_set>
@@ -11,6 +12,8 @@
 #include <functional>
 #include <utility>
 #include <atomic>
+#include <optional>
+#include <mutex>
 
 #include "grpc_client.h"
 
@@ -90,18 +93,28 @@ public:
     static const std::string fallbackAddress;
     static const std::string siteconfName;
   };
+  //Dynamic quantities of servers
+  struct ServerHealth {
+    bool live{false};
+    bool ready{false};
+
+    uint64_t inferenceCount{0};
+    uint64_t failureCount{0};
+    double avgQueueTimeMs{0.0};
+    double avgInferTimeMs{0.0};
+  };
   struct Model {
     Model(const std::string& path_ = "") : path(path_) {}
-
     //members
     std::string path;
     std::unordered_set<std::string> servers;
     std::unordered_set<unsigned> modules;
+    int refCount{0};  // for dynamic loading on fallback server
+    bool isLoaded() const { return refCount > 0; }
   };
   struct Module {
     //currently assumes that a module can only have one associated model
     Module(const std::string& model_) : model(model_) {}
-
     //members
     std::string model;
   };
@@ -111,11 +124,39 @@ public:
 
   //accessors
   void addModel(const std::string& modelName, const std::string& path);
-  Server serverInfo(const std::string& model, const std::string& preferred = "") const;
+
+  const std::string* resolveServerName(const std::string& model, const std::string& preferred = "") const;
+  const std::pair<const std::string, Server>& resolveServer(const std::string& model,
+                                                            const std::string& preferred = "") const;
+  std::vector<std::string> unassignedModels() const;
+
+  // update health stats of all servers
+  void updateServerHealth(const std::string& modelName = "") const;
+
+  // return the best server for retry, ignore the current server
+  std::optional<std::string> getBestServer(const std::string& modelName, const std::string& IgnoreServer = "") const;
+
+  // helper functions to get server statistics?
+  //  - getServerSideStatus()
+  //  - updateServerStatus()
+  //    - loop over servers_ get statistics
+  //  - getBestServer(model)
+  //    - call updateServerStatus()
+  //    - loop over servers_ get their statistics, compute metric, return server name
+
   const std::string& pid() const { return pid_; }
   void notifyCallStatus(bool status) const;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  // Dynamic model loading/unloading - only supported for the fallback server
+  // The fallback server must be started with explicit model control mode
+  // (--model-control-mode explicit) for these functions to work
+  bool loadModel(const std::string& modelName);
+  bool unloadModel(const std::string& modelName);
+  // Start the fallback server if enabled and not already running (idempotent)
+  void startFallbackServer();
+  bool fallbackStarted() const { return startedFallback_; }
 
 private:
   void preallocate(edm::service::SystemBounds const&);
@@ -128,6 +169,9 @@ private:
   //helper
   template <typename LOG>
   void printFallbackServerLog() const;
+  // Internal helpers that operate on Model directly (caller holds lock)
+  bool loadModel(const std::string& modelName, Model& model);
+  bool unloadModel(const std::string& modelName, Model& model);
 
   bool verbose_;
   FallbackOpts fallbackOpts_;
@@ -136,12 +180,18 @@ private:
   bool startedFallback_;
   mutable std::atomic<int> callFails_;
   std::string pid_;
-  std::unordered_map<std::string, Model> unservedModels_;
   //this represents a many:many:many map
   std::unordered_map<std::string, Server> servers_;
+  //server health needs concurrent-safe edits
+  tbb::concurrent_hash_map<std::string, ServerHealth> serversHealth_;
   std::unordered_map<std::string, Model> models_;
   std::unordered_map<unsigned, Module> modules_;
   int numberOfThreads_;
+
+  //Dynamic model loading and unloading (fallback server only)
+  std::mutex modelLoadMutex_;
+  // Model names currently loaded on the fallback server
+  std::unordered_set<std::string> fallbackLoadedModels_;
 };
 
 #endif

--- a/HeterogeneousCore/SonicTriton/python/customize.py
+++ b/HeterogeneousCore/SonicTriton/python/customize.py
@@ -13,12 +13,12 @@ def getParser():
     from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
     parser = ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter)
     parser.add_argument("--maxEvents", default=-1, type=int, help="Number of events to process (-1 for all)")
-    parser.add_argument("--serverName", default="default", type=str, help="name for server (used internally)")
-    parser.add_argument("--address", default="", type=str, help="server address")
-    parser.add_argument("--port", default=8001, type=int, help="server port")
+    parser.add_argument("--address", nargs=3, action="append", metavar=("NAME", "HOST", "PORT"),
+                        dest="addresses", default=[],
+                        help="Triton server entry: name host port (repeatable, e.g. --address server1 0.0.0.0 8011)")
     parser.add_argument("--timeout", default=30, type=int, help="timeout for requests")
     parser.add_argument("--timeoutUnit", default="seconds", type=str, help="unit for timeout")
-    parser.add_argument("--params", default="", type=str, help="json file containing server address/port")
+    parser.add_argument("--params", default="", type=str, help="json file containing server address/port(single-server)")
     parser.add_argument("--threads", default=1, type=int, help="number of threads")
     parser.add_argument("--streams", default=0, type=int, help="number of streams")
     parser.add_argument("--verbose", default=False, action="store_true", help="enable all verbose output")
@@ -36,12 +36,27 @@ def getParser():
     parser.add_argument("--imageName", default="", type=str, help="container image name for fallback server")
     parser.add_argument("--sandboxDir", default="", type=str, help="apptainer sandbox directory")
     parser.add_argument("--tempDir", default="", type=str, help="temp directory for fallback server")
+    parser.add_argument("--retryAction", default="same", type=str, choices=["same","diff"], help="retry policy: same server or different server")
 
     return parser
 
 def getOptions(parser, verbose=False):
     options = parser.parse_args()
 
+    # Legacy --params support: loads a single server and appends it to options.addresses
+    if len(options.params) > 0:
+        with open(options.params, 'r') as pfile:
+            pdict = json.load(pfile)
+        name = pdict.get("name", "default")
+        host = pdict["address"]
+        port = str(int(pdict["port"]))
+        options.addresses.append([name, host, port])
+        if verbose:
+            print("server (from params) = {}:{} [{}]".format(host, port, name))
+
+    if verbose:
+        for name, host, port in options.addresses:
+            print("server = {}:{} [{}]".format(host, port, name))
     if len(options.params)>0:
         with open(options.params,'r') as pfile:
             pdict = json.load(pfile)
@@ -76,13 +91,13 @@ def applyOptions(process, options, applyToModules=False):
         process.TritonService.fallback.device = options.device
         if len(options.fallbackName)>0:
             process.TritonService.fallback.instanceBaseName = options.fallbackName
-        if len(options.address)>0:
+        for name, host, port in options.addresses:
             process.TritonService.servers.append(
                 dict(
-                    name = options.serverName,
-                    address = options.address,
-                    port = options.port,
-                    useSsl = options.ssl,
+                    name    = name,
+                    address = host,
+                    port    = int(port),
+                    useSsl  = options.ssl,
                 )
             )
 
@@ -92,12 +107,19 @@ def applyOptions(process, options, applyToModules=False):
     return process
 
 def getClientOptions(options):
+    action = cms.PSet(
+                retryType = cms.string('RetrySameServerAction'),
+                allowedTries = cms.untracked.uint32(options.tries))
+    if options.retryAction != 'same':
+        action.retryType = cms.string('RetryActionDiffServer')
+
+    fallback = cms.PSet(retryType = cms.string('RetryFallbackServerAction'))
     return dict(
         compression = cms.untracked.string(options.compression),
         useSharedMemory = cms.untracked.bool(not options.noShm),
         timeout = cms.untracked.uint32(options.timeout),
         timeoutUnit = cms.untracked.string(options.timeoutUnit),
-        allowedTries = cms.untracked.uint32(options.tries),
+        Retry = cms.VPSet(action,fallback)
     )
 
 def applyClientOptions(client, options):

--- a/HeterogeneousCore/SonicTriton/scripts/cmsTriton
+++ b/HeterogeneousCore/SonicTriton/scripts/cmsTriton
@@ -30,6 +30,7 @@ if [ "$OSVERSION" -eq 7 ]; then
 fi
 DEVICE=auto
 THREADCONTROL=""
+MODELCONTROL="explicit"
 
 get_sandbox(){
 	if [ -z "$SANDBOX" ]; then
@@ -53,6 +54,7 @@ usage() {
 	$ECHO "-g [device] \t device choice: auto (try to detect GPU), CPU, GPU (default: ${DEVICE})"
 	$ECHO "-i [name]   \t server image name (default: ${IMAGE})"
 	$ECHO "-I [num]    \t number of model instances (default: ${INSTANCES} -> means no local editing of config files)"
+	$ECHO "-L          \t disable explicit model control mode (enabled by default for dynamic model loading)"
 	$ECHO "-M [dir]    \t model repository (can be given more than once)"
 	$ECHO "-m [dir]    \t specific model directory (can be given more than once)"
 	$ECHO "-n [name]   \t name of container instance, also used for default hidden temporary dir (default: ${SERVER})"
@@ -78,7 +80,7 @@ if [ -e /run/shm ]; then
 	SHM=/run/shm
 fi
 
-while getopts "cC:Dd:fg:i:I:M:m:n:P:p:r:s:t:vw:h" opt; do
+while getopts "cC:Dd:fg:i:I:LM:m:n:P:p:r:s:t:vw:h" opt; do
 	case "$opt" in
 		c) CLEANUP=""
 		;;
@@ -95,6 +97,8 @@ while getopts "cC:Dd:fg:i:I:M:m:n:P:p:r:s:t:vw:h" opt; do
 		i) IMAGE="$OPTARG"
 		;;
 		I) INSTANCES="$OPTARG"
+		;;
+		L) MODELCONTROL="none"
 		;;
 		M) REPOS+=("$OPTARG")
 		;;
@@ -246,6 +250,9 @@ start_docker(){
 	# mount all model repositories
 	MOUNTARGS=""
 	REPOARGS=""
+	if [ -n "$MODELCONTROL" ]; then
+		REPOARGS="--model-control-mode=${MODELCONTROL}"
+	fi
 	for REPO in ${REPOS[@]}; do
 		MOUNTARGS="$MOUNTARGS -v$REPO:$REPO"
 		REPOARGS="$REPOARGS --model-repository=${REPO}"
@@ -266,6 +273,9 @@ start_podman(){
 	# mount all model repositories
 	MOUNTARGS=""
 	REPOARGS=""
+	if [ -n "$MODELCONTROL" ]; then
+		REPOARGS="--model-control-mode=${MODELCONTROL}"
+	fi
 	for REPO in ${REPOS[@]}; do
 		MOUNTARGS="$MOUNTARGS --volume $REPO:$REPO"
 		REPOARGS="$REPOARGS --model-repository=${REPO}"
@@ -286,6 +296,9 @@ start_apptainer(){
 	# mount all model repositories
 	MOUNTARGS=""
 	REPOARGS=""
+	if [ -n "$MODELCONTROL" ]; then
+		REPOARGS="--model-control-mode=${MODELCONTROL}"
+	fi
 	for REPO in ${REPOS[@]}; do
 		MOUNTARGS="$MOUNTARGS -B $REPO"
 		REPOARGS="$REPOARGS --model-repository=${REPO}"

--- a/HeterogeneousCore/SonicTriton/src/RetryActionDiffServer.cc
+++ b/HeterogeneousCore/SonicTriton/src/RetryActionDiffServer.cc
@@ -1,0 +1,50 @@
+#include "HeterogeneousCore/SonicTriton/interface/RetryActionDiffServer.h"
+#include "HeterogeneousCore/SonicTriton/interface/TritonClient.h"
+#include "HeterogeneousCore/SonicTriton/interface/TritonService.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+RetryActionDiffServer::RetryActionDiffServer(const edm::ParameterSet& conf, SonicClientBase* client)
+    : RetryActionBase(conf, client) {}
+
+void RetryActionDiffServer::start() {
+  this->shouldRetry_ = true;
+  tries_ = 0;
+}
+
+void RetryActionDiffServer::retry() {
+  ++tries_;
+  if (tries_ >= 1) {
+    shouldRetry_ = false;  // Flip flag when max retries are reached. Allow 1 try for now.
+    edm::LogInfo("RetryDiffServerAction") << "Max retry attempts reached. No further retries.";
+  }
+  try {
+    auto* tritonClient = static_cast<TritonClient*>(client_);
+    edm::LogInfo("RetryActionDiffServer") << "Asking for a different server from TritonService";
+    auto ts = tritonClient->service();
+
+    // First, try to find another remote server
+    auto bestServerName = ts->getBestServer(tritonClient->modelName(), tritonClient->serverName());
+
+    if (bestServerName) {
+      edm::LogInfo("RetryActionDiffServer") << "Got best server from service ";
+      tritonClient->updateServer(*bestServerName);
+      edm::LogInfo("RetryActionDiffServer") << "eval() with new server";
+      eval();
+      return;
+    } else {
+      edm::LogWarning("RetryActionDiffServer")
+          << "No alternative server found for model " << tritonClient->modelName() << ". Now call client->finish()";
+      finish(false);
+      return;
+    }
+  } catch (TritonException& e) {
+    e.convertToWarning();
+  } catch (std::exception& e) {
+    edm::LogError("RetryActionDiffServer") << "Failed to retry with alternative server: " << e.what();
+  } catch (...) {
+    edm::LogError("RetryActionDiffServer: UnknownFailure") << "An unknown exception was thrown";
+  }
+}
+
+DEFINE_RETRY_ACTION(RetryActionDiffServer);

--- a/HeterogeneousCore/SonicTriton/src/RetryFallbackServerAction.cc
+++ b/HeterogeneousCore/SonicTriton/src/RetryFallbackServerAction.cc
@@ -1,0 +1,54 @@
+// RetryFallbackServerAction: last-resort retry action for TritonClient.
+//
+// When all other retry actions have been exhausted, this action loads the
+// client's model onto the fallback (local) Triton server and re-runs
+// inference there.  It fires at most once per inference call.
+//
+// Usage add to the Retry VPSet *after* all other retry actions:
+//   cms.PSet(retryType = cms.string("RetryFallbackServerAction"))
+//
+// Requirements:
+//   - TritonService fallback must be enabled in the job configuration.
+//   - The model must have a modelConfigPath / repository path known to
+//     TritonService so it can be loaded dynamically.
+
+#include "HeterogeneousCore/SonicTriton/interface/RetryFallbackServerAction.h"
+#include "HeterogeneousCore/SonicTriton/interface/TritonClient.h"
+#include "HeterogeneousCore/SonicTriton/interface/TritonService.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+RetryFallbackServerAction::RetryFallbackServerAction(const edm::ParameterSet& conf, SonicClientBase* client)
+    : RetryActionBase(conf, client) {}
+
+void RetryFallbackServerAction::start() {
+  this->shouldRetry_ = true;
+  tries_ = 0;
+}
+
+void RetryFallbackServerAction::retry() {
+  // Allow only one fallback attempt per inference call.
+  shouldRetry_ = false;
+
+  auto* tc = dynamic_cast<TritonClient*>(client_);
+  if (!tc) {
+    // Should never happen in a correctly configured job.
+    edm::LogWarning("RetryFallbackServerAction")
+        << "client_ is not a TritonClient — cannot redirect to fallback server";
+    finish(false);
+    return;
+  }
+
+  CMS_SA_ALLOW try {
+    // Start the fallback server (idempotent), load the model, and point
+    // the client's gRPC connection at the fallback URL.
+    tc->switchToFallback();
+    // Re-run the inference on the fallback server.
+    eval();
+  } catch (...) {
+    // Non-retryable: propagate the exception so the job fails cleanly.
+    finish(false);
+  }
+}
+DEFINE_RETRY_ACTION(RetryFallbackServerAction);

--- a/HeterogeneousCore/SonicTriton/src/TritonClient.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonClient.cc
@@ -1,3 +1,4 @@
+#include "FWCore/Concurrency/interface/WaitingTask.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 #include "FWCore/ParameterSet/interface/allowedValues.h"
@@ -28,6 +29,19 @@
 namespace tc = triton::client;
 
 namespace {
+  // Minimal ParameterSet to satisfy SonicClientBase requirements during unit tests
+  edm::ParameterSet makeMinimalSonicParamsForTest() {
+    edm::ParameterSet params;
+    params.addParameter<std::string>("mode", "PseudoAsync");
+
+    edm::ParameterSet defaultRetry;
+    defaultRetry.addParameter<std::string>("retryType", "RetrySameServerAction");
+    defaultRetry.addUntrackedParameter<unsigned>("allowedTries", 0u);
+    std::vector<edm::ParameterSet> retryVec{defaultRetry};
+    params.addParameter<std::vector<edm::ParameterSet>>("Retry", retryVec);
+
+    return params;
+  }
   grpc_compression_algorithm getCompressionAlgo(const std::string& name) {
     if (name.empty() or name.compare("none") == 0)
       return grpc_compression_algorithm::GRPC_COMPRESS_NONE;
@@ -61,7 +75,7 @@ TritonClient::TritonClient(const edm::ParameterSet& params, const std::string& d
       useSharedMemory_(params.getUntrackedParameter<bool>("useSharedMemory")),
       compressionAlgo_(getCompressionAlgo(params.getUntrackedParameter<std::string>("compression"))) {
   options_.emplace_back(params.getParameter<std::string>("modelName"));
-  //get appropriate server for this model
+
   edm::Service<TritonService> ts;
 
   // We save the token to be able to notify the service in case of an exception in the evaluate method.
@@ -70,21 +84,8 @@ TritonClient::TritonClient(const edm::ParameterSet& params, const std::string& d
   // create the context.
   token_ = edm::ServiceRegistry::instance().presentToken();
 
-  const auto& server =
-      ts->serverInfo(options_[0].model_name_, params.getUntrackedParameter<std::string>("preferredServer"));
-  serverType_ = server.type;
-  edm::LogInfo("TritonDiscovery") << debugName_ << " assigned server: " << server.url;
-  //enforce sync mode for fallback CPU server to avoid contention
-  //todo: could enforce async mode otherwise (unless mode was specified by user?)
-  if (serverType_ == TritonServerType::LocalCPU)
-    setMode(SonicMode::Sync);
-  isLocal_ = serverType_ == TritonServerType::LocalCPU or serverType_ == TritonServerType::LocalGPU;
-
-  //connect to the server
-  TRITON_THROW_IF_ERROR(
-      tc::InferenceServerGrpcClient::Create(&client_, server.url, false, server.useSsl, server.sslOptions),
-      "TritonClient(): unable to create inference context",
-      localService());
+  //Connect to server
+  updateServer(params.getUntrackedParameter<std::string>("preferredServer"));
 
   //set options
   options_[0].model_version_ = params.getParameter<std::string>("modelVersion");
@@ -344,6 +345,22 @@ bool TritonClient::handle_exception(F&& call) {
   }
 }
 
+template <typename F>
+bool TritonClient::handle_exception_holder(edm::WaitingTaskWithArenaHolder& fh, F&& call) {
+  CMS_SA_ALLOW try {
+    call();
+    return true;
+  } catch (TritonException& e) {
+    e.convertToWarning();
+    inferSuccess_ = false;
+    fh.doneWaiting(nullptr);  // retryable: schedules finish(false) on TBB
+    return false;
+  } catch (...) {
+    fh.doneWaiting(std::current_exception());  // non-retryable
+    return false;
+  }
+}
+
 const TritonService* TritonClient::service() const {
   edm::ServiceRegistry::Operate op(token_);
   edm::Service<TritonService> ts;
@@ -377,7 +394,7 @@ void TritonClient::getResults(const std::vector<std::shared_ptr<tc::InferResult>
 //default case for sync and pseudo async
 void TritonClient::evaluate() {
   //undo previous signal from TritonException
-  if (tries_ > 0) {
+  if (totalTries_ > 0) {
     // If we are retrying then the evaluate method is called outside the frameworks TBB thread pool.
     // So we need to setup the service token for the current thread to access the service registry.
     edm::ServiceRegistry::Operate op(token_);
@@ -424,6 +441,7 @@ void TritonClient::evaluate() {
       element.second.prepare();
     }
   });
+  //edm::LogInfo("TritonClient") << "evaluate() return 1";
   if (!success)
     return;
 
@@ -433,55 +451,74 @@ void TritonClient::evaluate() {
     if (verbose())
       start_status = getServerSideStatus();
   });
+  //edm::LogInfo("TritonClient") << "evaluate() return 2";
   if (!success)
     return;
 
   if (mode_ == SonicMode::Async) {
-    //non-blocking call
-    success = handle_exception([&]() {
-      TRITON_THROW_IF_ERROR(client_->AsyncInferMulti(
-                                [start_status, this](std::vector<tc::InferResult*> resultsTmp) {
-                                  //immediately convert to shared_ptr
-                                  const auto& results = convertToShared(resultsTmp);
-                                  //check results
-                                  for (auto ptr : results) {
-                                    auto success = handle_exception([&]() {
-                                      TRITON_THROW_IF_ERROR(
-                                          ptr->RequestStatus(), "evaluate(): unable to get result(s)", localService());
-                                    });
-                                    if (!success)
-                                      return;
-                                  }
+    // Reset before each inference attempt: false=retryable/not-yet-succeeded.
+    // The callback sets this to true on success before calling doneWaiting(nullptr).
+    // If the launch throws (lambda destroyed inside AsyncInferMulti), the holder destructor
+    // calls doneWaiting(nullptr) with inferSuccess_=false → finish(false) [retryable] on TBB.
+    inferSuccess_ = false;
 
-                                  if (verbose()) {
-                                    inference::ModelStatistics end_status;
-                                    auto success = handle_exception([&]() { end_status = getServerSideStatus(); });
-                                    if (!success)
-                                      return;
-
-                                    const auto& stats = summarizeServerStats(start_status, end_status);
-                                    reportServerSideStats(stats);
-                                  }
-
-                                  //check result
-                                  auto success = handle_exception([&]() { getResults(results); });
-                                  if (!success)
-                                    return;
-
-                                  //finish
-                                  finish(true);
-                                },
-                                options_,
-                                inputsTriton,
-                                outputsTriton,
-                                headers_,
-                                compressionAlgo_),
-                            "evaluate(): unable to launch async run",
-                            localService());
+    // Create holder[finish]: when doneWaiting() is called, finish() is scheduled as a TBB task
+    // so retry logic (finish→retry→updateServer) never runs on the gRPC callback thread.
+    auto* finishTask = edm::make_waiting_task([this](std::exception_ptr const* excptr) {
+      if (excptr)
+        finish(false, *excptr);  // non-retryable exception
+      else
+        finish(inferSuccess_.load());  // true=success, false=retryable failure
     });
-    if (!success)
-      return;
+    edm::WaitingTaskWithArenaHolder finishHolder(*holder_->group(), finishTask);
+
+    // Launch async inference.
+    // On TritonException: fh destructor (in destroyed lambda) calls doneWaiting(nullptr)
+    // → schedules finish(false) [retryable] on TBB. Do NOT call finish() directly here.
+    CMS_SA_ALLOW try {
+      TRITON_THROW_IF_ERROR(
+          client_->AsyncInferMulti(
+              [start_status, fh = std::move(finishHolder), this](std::vector<tc::InferResult*> resultsTmp) mutable {
+                //immediately convert to shared_ptr
+                const auto& results = convertToShared(resultsTmp);
+                //check results
+                for (auto ptr : results) {
+                  auto ok = handle_exception_holder(fh, [&]() {
+                    TRITON_THROW_IF_ERROR(ptr->RequestStatus(), "evaluate(): unable to get result(s)", localService());
+                  });
+                  if (!ok)
+                    return;
+                }
+
+                if (verbose()) {
+                  inference::ModelStatistics end_status;
+                  auto ok = handle_exception_holder(fh, [&]() { end_status = getServerSideStatus(); });
+                  if (!ok)
+                    return;
+                  const auto& stats = summarizeServerStats(start_status, end_status);
+                  reportServerSideStats(stats);
+                }
+
+                auto ok = handle_exception_holder(fh, [&]() { getResults(results); });
+                if (!ok)
+                  return;
+
+                inferSuccess_ = true;
+                fh.doneWaiting(nullptr);  // success: schedules finish(true) on TBB
+              },
+              options_,
+              inputsTriton,
+              outputsTriton,
+              headers_,
+              compressionAlgo_),
+          "evaluate(): unable to launch async run",
+          localService());
+    } catch (TritonException& e) {
+      e.convertToWarning();
+      // fh destructor already called doneWaiting(nullptr) → finish(false) scheduled on TBB
+    }
   } else {
+    //edm::LogInfo("TritonClient") << "evaluate() return 4";
     //blocking call
     std::vector<tc::InferResult*> resultsTmp;
     success = handle_exception([&]() {
@@ -582,6 +619,54 @@ inference::ModelStatistics TritonClient::getServerSideStatus() const {
   return inference::ModelStatistics{};
 }
 
+void TritonClient::updateServer(const std::string& serverName) {
+  //get appropriate server for this model
+  auto ts = service();
+
+  const auto& serverMap = ts->resolveServer(options_[0].model_name_, serverName);
+
+  const auto& server = serverMap.second;
+
+  //update server name
+  serverName_ = serverMap.first;
+
+  serverType_ = server.type;
+  edm::LogInfo("TritonDiscovery") << debugName_ << " assigned server: " << server.url;
+  //enforce sync mode for fallback CPU server to avoid contention
+  //todo: could enforce async mode otherwise (unless mode was specified by user?)
+  if (serverType_ == TritonServerType::LocalCPU)
+    setMode(SonicMode::Sync);
+  isLocal_ = serverType_ == TritonServerType::LocalCPU or serverType_ == TritonServerType::LocalGPU;
+
+  // updateServer() is always called from a TBB thread (via finish() -> retry() -> updateServer()),
+  // so it is safe to destroy the old gRPC client immediately.
+  client_.reset();
+
+  //connect to the server
+  TRITON_THROW_IF_ERROR(
+      tc::InferenceServerGrpcClient::Create(&client_, server.url, false, server.useSsl, server.sslOptions),
+      "TritonClient(): unable to create inference context",
+      localService());
+}
+
+void TritonClient::switchToFallback() {
+  edm::ServiceRegistry::Operate op(token_);
+  edm::Service<TritonService> ts;
+
+  // Start the fallback server if it has not been started yet (idempotent).
+  ts->startFallbackServer();
+  if (!ts->fallbackStarted())
+    throw TritonException("LocalFailure")
+        << "TritonClient::switchToFallback: fallback server is not available "
+           "(check that TritonService fallback.enable = True and a model path is configured)";
+
+  // Dynamically load this client's model onto the fallback server.
+  ts->loadModel(options_[0].model_name_);
+
+  // Re-point the gRPC connection at the fallback server.
+  updateServer(TritonService::Server::fallbackName);
+}
+
 //for fillDescriptions
 void TritonClient::fillPSetDescription(edm::ParameterSetDescription& iDesc) {
   edm::ParameterSetDescription descClient;
@@ -599,3 +684,22 @@ void TritonClient::fillPSetDescription(edm::ParameterSetDescription& iDesc) {
   descClient.addUntracked<std::vector<std::string>>("outputs", {});
   iDesc.add<edm::ParameterSetDescription>("Client", descClient);
 }
+
+void TritonClient::connectToServer(const std::string& url) {
+  // Update client state for a generic remote server
+  serverType_ = TritonServerType::Remote;
+  isLocal_ = false;
+
+  edm::LogInfo("TritonDiscovery") << debugName_ << " connecting to server: " << url;
+
+  // Use default SSL options
+  triton::client::SslOptions sslOptions;
+  bool useSsl = false;  // Assuming no SSL for direct URL connection
+
+  // Connect to the server
+  TRITON_THROW_IF_ERROR(triton::client::InferenceServerGrpcClient::Create(&client_, url, false, useSsl, sslOptions),
+                        "TritonClient::connectToServer(): unable to create inference context");
+}
+
+//constructor for testing
+TritonClient::TritonClient() : SonicClient(makeMinimalSonicParamsForTest(), "TritonClient_test", "TritonClient") {}

--- a/HeterogeneousCore/SonicTriton/src/TritonService.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonService.cc
@@ -120,11 +120,14 @@ TritonService::TritonService(const edm::ParameterSet& pset, edm::ActivityRegistr
           << "TritonService: Not allowed to specify more than one server with same name (" << serverName << ")";
   }
 
-  //loop over all servers: check which models they have
+  //loop over all servers: check which models they have, populate serverHealth
   std::string msg;
   if (verbose_)
     msg = "List of models for each server:\n";
   for (auto& [serverName, server] : servers_) {
+    //populate serverHealth
+    serversHealth_.emplace(serverName, ServerHealth{});
+
     std::unique_ptr<tc::InferenceServerGrpcClient> client;
     TRITON_THROW_IF_ERROR(
         tc::InferenceServerGrpcClient::Create(&client, server.url, false, server.useSsl, server.sslOptions),
@@ -138,7 +141,8 @@ TritonService::TritonService(const edm::ParameterSet& pset, edm::ActivityRegistr
         edm::LogInfo("TritonService") << "Server " << serverName << ": url = " << server.url
                                       << ", version = " << serverMetaResponse.version();
       else
-        edm::LogInfo("TritonService") << "unable to get metadata for " + serverName + " (" + server.url + ")";
+        edm::LogInfo("TritonService") << "unable to get metadata for " + serverName + " (" + server.url + ")"
+                                      << err.Message();
     }
 
     //if this query fails, it indicates that the server is nonresponsive or saturated
@@ -191,64 +195,214 @@ void TritonService::addModel(const std::string& modelName, const std::string& pa
   if (!allowAddModel_)
     throw cms::Exception("DisallowedAddModel")
         << "TritonService: Attempt to call addModel() outside of module constructors";
-  //if model is not in the list, then no specified server provides it
-  auto mit = models_.find(modelName);
-  if (mit == models_.end()) {
-    auto& modelInfo(unservedModels_.emplace(modelName, path).first->second);
-    modelInfo.modules.insert(currentModuleId_);
-    //only keep track of modules that need unserved models
-    modules_.emplace(currentModuleId_, modelName);
-  }
+
+  auto& modelInfo(models_.emplace(modelName, path).first->second);
+  // Update path if model was previously added (e.g., by server scanning) with empty path
+  if (modelInfo.path.empty() && !path.empty())
+    modelInfo.path = path;
+
+  modelInfo.modules.insert(currentModuleId_);
+  modules_.emplace(currentModuleId_, modelName);
 }
 
 void TritonService::postModuleConstruction(edm::ModuleDescription const& desc) { allowAddModel_ = false; }
 
 void TritonService::preModuleDestruction(edm::ModuleDescription const& desc) {
-  //remove destructed modules from unserved list
-  if (unservedModels_.empty())
-    return;
   auto id = desc.id();
   auto oit = modules_.find(id);
   if (oit != modules_.end()) {
     const auto& moduleInfo(oit->second);
-    auto mit = unservedModels_.find(moduleInfo.model);
-    if (mit != unservedModels_.end()) {
+    auto mit = models_.find(moduleInfo.model);
+    if (mit != models_.end()) {
       auto& modelInfo(mit->second);
       modelInfo.modules.erase(id);
-      //remove a model if it is no longer needed by any modules
-      if (modelInfo.modules.empty())
-        unservedModels_.erase(mit);
     }
     modules_.erase(oit);
   }
 }
 
-//second return value is only true if fallback CPU server is being used
-TritonService::Server TritonService::serverInfo(const std::string& model, const std::string& preferred) const {
+// Returns the name of the server assigned to serve the given model, or nullptr if no server is currently assigned.
+// If a preferred server(current server) is specified but unavailable, falls back to any assigned server.
+// Callers are responsible for handling the nullptr case.
+const std::string* TritonService::resolveServerName(const std::string& model, const std::string& preferred) const {
   auto mit = models_.find(model);
-  if (mit == models_.end())
-    throw cms::Exception("MissingModel") << "TritonService: There are no servers that provide model " << model;
-  const auto& modelInfo(mit->second);
-  const auto& modelServers = modelInfo.servers;
+  if (mit == models_.end() || mit->second.servers.empty())
+    return nullptr;  // no server assigned - caller decides what to do
 
-  auto msit = modelServers.end();
+  const auto& modelServers = mit->second.servers;
+
   if (!preferred.empty()) {
-    msit = modelServers.find(preferred);
-    //todo: add a "strict" parameter to stop execution if preferred server isn't found?
-    if (msit == modelServers.end())
-      edm::LogWarning("PreferredServer") << "Preferred server " << preferred << " for model " << model
-                                         << " not available, will choose another server";
+    auto msit = modelServers.find(preferred);
+    if (msit != modelServers.end())
+      return &(*msit);
+    edm::LogWarning("PreferredServer") << "Preferred server " << preferred << " for model " << model
+                                       << " not available, will choose another server";
   }
-  const auto& serverName(msit == modelServers.end() ? *modelServers.begin() : preferred);
-
-  //todo: use some algorithm to select server rather than just picking arbitrarily
-  const auto& server(servers_.find(serverName)->second);
-  return server;
+  //Prefer remote servers over fallback if available
+  if (modelServers.size() > 1) {
+    auto rit = std::find_if(modelServers.begin(), modelServers.end(), [this](const std::string& name) {
+      auto sit = servers_.find(name);
+      return sit != servers_.end() && !sit->second.isFallback;
+    });
+    if (rit != modelServers.end())
+      return &(*rit);
+  }
+  return &(*modelServers.begin());
 }
 
-void TritonService::preBeginJob(edm::ProcessContext const&) {
-  //only need fallback if there are unserved models
-  if (!fallbackOpts_.enable or unservedModels_.empty())
+// Returns the full server info for the server assigned to serve the given model.
+// Throws MissingModel if no server is currently assigned.
+// Wraps resolveServerName; use that directly if nullptr should be handled by the caller
+const std::pair<const std::string, TritonService::Server>& TritonService::resolveServer(
+    const std::string& model, const std::string& preferred) const {
+  const auto* name = resolveServerName(model, preferred);
+  if (!name)
+    throw cms::Exception("MissingModel") << "TritonService: There are no servers that provide model " << model;
+  return *servers_.find(*name);
+}
+
+// Returns the list of model names that are not currently assigned to any server.
+std::vector<std::string> TritonService::unassignedModels() const {
+  std::vector<std::string> result;
+  for (const auto& [name, info] : models_) {
+    if (info.servers.empty())
+      result.push_back(name);
+  }
+  return result;
+}
+
+void TritonService::updateServerHealth(const std::string& modelName) const {
+  for (auto& [serverName, server] : servers_) {
+    edm::LogInfo("TritonService") << "Updating server health for server = " << serverName;
+    if (server.isFallback) {
+      edm::LogInfo("TritonService") << serverName << " is skipped because it is a fallback server";
+      continue;  // fallback is a last resort, not a candidate for getBestServer
+    }
+    try {
+      std::unique_ptr<tc::InferenceServerGrpcClient> client;
+      TRITON_THROW_IF_ERROR(
+          tc::InferenceServerGrpcClient::Create(&client, server.url, false, server.useSsl, server.sslOptions),
+          "TritonService(): unable to create inference context for " + serverName + " (" + server.url + ")");
+
+      bool live = false, ready = false;
+      TRITON_THROW_IF_ERROR(client->IsServerLive(&live),
+                            "TritonService(): unable to query IsServerLive " + serverName + " (" + server.url + ")");
+      TRITON_THROW_IF_ERROR(client->IsServerReady(&ready),
+                            "TritonService(): unable to query IsServerReady " + serverName + " (" + server.url + ")");
+
+      edm::LogInfo("TritonService") << serverName << " : live = " << live << " ready = " << ready;
+
+      inference::ModelStatisticsResponse stats;
+      if (!modelName.empty()) {
+        client->ModelInferenceStatistics(&stats, modelName);
+      } else {
+        for (const auto& m : server.models) {
+          client->ModelInferenceStatistics(&stats, m);
+        }
+      }
+
+      uint64_t infer_count = 0, queue_count = 0, failures = 0;
+      double avgQueueTimeMs = 0.0;
+      double avgInferTimeMs = 0.0;
+
+      for (const auto& mstat : stats.model_stats()) {
+        if (modelName.empty() || mstat.name() == modelName) {
+          const auto& infer = mstat.inference_stats();
+
+          infer_count += infer.compute_infer().count();
+          avgInferTimeMs += infer.compute_infer().ns() / 1e3;
+          queue_count += infer.queue().count();
+          avgQueueTimeMs += infer.queue().ns() / 1e3;
+          failures += infer.fail().count();
+        }
+      }
+      // Update health map safely with accessor
+      tbb::concurrent_hash_map<std::string, ServerHealth>::accessor acc;
+      serversHealth_.find(acc, serverName);
+
+      ServerHealth& health = acc->second;
+      health.live = live;
+      health.ready = ready;
+      health.failureCount = failures;
+      health.avgQueueTimeMs = (queue_count > 0) ? avgQueueTimeMs / queue_count : 0.0;
+      health.avgInferTimeMs = (infer_count > 0) ? avgInferTimeMs / infer_count : 0.0;
+
+    } catch (const TritonException& e) {
+      // mark existing entry unhealthy if present
+      tbb::concurrent_hash_map<std::string, ServerHealth>::accessor acc;
+      if (serversHealth_.find(acc, serverName)) {
+        ServerHealth& health = acc->second;
+        health.live = false;
+        health.ready = false;
+      }
+    } catch (const std::exception& e) {
+      // fallback for other exceptions
+      tbb::concurrent_hash_map<std::string, ServerHealth>::accessor acc;
+      if (serversHealth_.find(acc, serverName)) {
+        ServerHealth& health = acc->second;
+        health.live = false;
+        health.ready = false;
+      }
+    }
+  }
+}
+
+std::optional<std::string> TritonService::getBestServer(const std::string& modelName,
+                                                        const std::string& IgnoreServer) const {
+  std::optional<std::string> bestServerName;
+  ServerHealth bestHealth;
+
+  // get fresh ServerHealth statistics
+  updateServerHealth(modelName);
+  edm::LogInfo("TritonService") << "Getting best server";
+
+  for (auto& [serverName, server] : servers_) {
+    if (serverName == IgnoreServer) {
+      edm::LogInfo("TritonService") << serverName << " is ignored";
+      continue;  // skip ignored server
+    }
+    if (server.isFallback) {
+      edm::LogInfo("TritonService") << serverName << " is skipped because it is a fallback server";
+      continue;  // fallback is a last resort, not a candidate for getBestServer
+    }
+    if (server.models.find(modelName) == server.models.end()) {
+      edm::LogInfo("TritonService") << serverName << " is skipped because it does not have " << modelName;
+      continue;  // server doesn't have model
+    }
+
+    tbb::concurrent_hash_map<std::string, ServerHealth>::const_accessor acc;
+    if (!serversHealth_.find(acc, serverName)) {
+      edm::LogInfo("TritonService") << serverName << " is skipped because it does not have health info";
+      continue;  // no health info
+    }
+
+    const ServerHealth& health = acc->second;
+
+    if (!health.live || !health.ready) {
+      edm::LogInfo("TritonService") << serverName << " is skipped because is not live or ready";
+      continue;  // skip unhealthy
+    }
+
+    // Select server according to rules:
+    // 1) lowest failureCount
+    // 2) tie-breaker: lowest avgQueueTimeMs
+    if (!bestServerName || health.failureCount < bestHealth.failureCount ||
+        (health.failureCount == bestHealth.failureCount && health.avgQueueTimeMs < bestHealth.avgQueueTimeMs)) {
+      bestServerName = serverName;
+      bestHealth = health;
+    }
+  }
+  if (verbose_ && bestServerName) {
+    edm::LogInfo("TritonDiscovery") << "Chosen server for model '" << modelName << "': " << *bestServerName
+                                    << " (failures=" << bestHealth.failureCount
+                                    << ", avgQueueTime=" << bestHealth.avgQueueTimeMs << " ms)";
+  }
+  return bestServerName;
+}
+
+void TritonService::startFallbackServer() {
+  // Idempotent: do nothing if already running or disabled
+  if (!fallbackOpts_.enable || startedFallback_)
     return;
 
   //include fallback server in set
@@ -262,10 +416,13 @@ void TritonService::preBeginJob(edm::ProcessContext const&) {
   std::string msg;
   if (verbose_)
     msg = "List of models for fallback server: ";
-  //all unserved models are provided by fallback server
+  // Provide all declared models with known paths via the fallback server
   auto& server(servers_.find(Server::fallbackName)->second);
-  for (const auto& [modelName, model] : unservedModels_) {
-    auto& modelInfo(models_.emplace(modelName, model).first->second);
+  for (const auto& [modelName, model] : models_) {
+    // Only seed models for which we have a repository path
+    if (model.path.empty())
+      continue;
+    auto& modelInfo(models_.find(modelName)->second);
     modelInfo.servers.insert(Server::fallbackName);
     server.models.insert(modelName);
     if (verbose_)
@@ -288,7 +445,9 @@ void TritonService::preBeginJob(edm::ProcessContext const&) {
     fallbackOpts_.command += " -r " + std::to_string(fallbackOpts_.retries);
   if (fallbackOpts_.wait >= 0)
     fallbackOpts_.command += " -w " + std::to_string(fallbackOpts_.wait);
-  for (const auto& [modelName, model] : unservedModels_) {
+  for (const auto& [modelName, model] : models_) {
+    if (model.path.empty())
+      continue;
     fallbackOpts_.command += " -m " + model.path;
   }
   std::string thread_string = " -I " + std::to_string(numberOfThreads_);
@@ -297,8 +456,7 @@ void TritonService::preBeginJob(edm::ProcessContext const&) {
     fallbackOpts_.command += " -i " + fallbackOpts_.imageName;
   if (!fallbackOpts_.sandboxDir.empty())
     fallbackOpts_.command += " -s " + fallbackOpts_.sandboxDir;
-  //don't need this anymore
-  unservedModels_.clear();
+  // models_ remains for runtime queries; nothing to clear here
 
   //get a random temporary directory if none specified
   if (fallbackOpts_.tempDir.empty()) {
@@ -358,6 +516,25 @@ void TritonService::preBeginJob(edm::ProcessContext const&) {
     throw edm::Exception(edm::errors::ExternalFailure)
         << "TritonService: Unknown port for fallback server, log follows:\n"
         << output;
+}
+
+void TritonService::preBeginJob(edm::ProcessContext const&) {
+  // Capture unassigned models *before* startFallbackServer() is called.
+  // startFallbackServer() seeds all known-path models into the fallback server
+  // set, which would make unassignedModels() return empty afterward.
+  const auto& unassigned = unassignedModels();
+
+  // Always start the fallback server so it is ready for on-demand model
+  // loading during retries, even when every model has a primary server.
+  startFallbackServer();
+
+  if (!unassigned.empty() && startedFallback_) {
+    auto& server(servers_.find(Server::fallbackName)->second);
+    for (const auto& modelName : unassigned) {
+      server.models.insert(modelName);
+      loadModel(modelName);
+    }
+  }
 }
 
 void TritonService::notifyCallStatus(bool status) const {
@@ -452,4 +629,108 @@ void TritonService::fillDescriptions(edm::ConfigurationDescriptions& description
   desc.add<edm::ParameterSetDescription>("fallback", fallbackDesc);
 
   descriptions.addWithDefaultLabel(desc);
+}
+
+bool TritonService::loadModel(const std::string& modelName) {
+  std::lock_guard<std::mutex> lock(modelLoadMutex_);
+
+  // Get model from models_ map (should exist from addModel during module construction)
+  auto mit = models_.find(modelName);
+  if (mit == models_.end()) {
+    edm::LogWarning("TritonService") << "loadModel: Model " << modelName << " not found in models_ map";
+    return false;
+  }
+
+  return loadModel(modelName, mit->second);
+}
+
+bool TritonService::loadModel(const std::string& modelName, Model& model) {
+  // if already loaded, bump refcount
+  if (model.refCount > 0) {
+    ++model.refCount;
+    if (verbose_)
+      edm::LogInfo("TritonService") << "Model " << modelName << " already loaded, ref count: " << model.refCount;
+    return true;
+  }
+
+  if (!startedFallback_) {
+    throw cms::Exception("TritonService")
+        << "loadModel: fallback server not started; cannot load model '" << modelName << "'";
+  }
+
+  auto sit = servers_.find(Server::fallbackName);
+  if (sit == servers_.end()) {
+    throw cms::Exception("TritonService") << "loadModel: fallback server not found";
+  }
+
+  std::unique_ptr<tc::InferenceServerGrpcClient> client;
+  TRITON_THROW_IF_ERROR(tc::InferenceServerGrpcClient::Create(
+                            &client, sit->second.url, false, sit->second.useSsl, sit->second.sslOptions),
+                        "loadModel: unable to create client for fallback server");
+
+  TRITON_THROW_IF_ERROR(client->LoadModel(modelName),
+                        "loadModel: failed to load model " + modelName + " on fallback server");
+
+  // Update state and tracking
+  model.refCount = 1;
+  model.servers.insert(Server::fallbackName);
+  sit->second.models.insert(modelName);
+  fallbackLoadedModels_.insert(modelName);
+
+  if (verbose_)
+    edm::LogInfo("TritonService") << "Successfully loaded model " << modelName << " on fallback server";
+  return true;
+}
+
+bool TritonService::unloadModel(const std::string& modelName) {
+  std::lock_guard<std::mutex> lock(modelLoadMutex_);
+
+  // Get model from models_ map
+  auto mit = models_.find(modelName);
+  if (mit == models_.end()) {
+    edm::LogWarning("TritonService") << "unloadModel: Model " << modelName << " not found in models_ map";
+    return false;
+  }
+
+  return unloadModel(modelName, mit->second);
+}
+
+bool TritonService::unloadModel(const std::string& modelName, Model& model) {
+  if (model.refCount == 0) {
+    edm::LogWarning("TritonService") << "unloadModel: Model " << modelName << " is not loaded";
+    return false;
+  }
+
+  if (model.refCount > 1) {
+    --model.refCount;
+    if (verbose_)
+      edm::LogInfo("TritonService") << "Model " << modelName << " still in use, ref count: " << model.refCount;
+    return true;
+  }
+
+  auto sit = servers_.find(Server::fallbackName);
+  if (sit == servers_.end()) {
+    edm::LogWarning("TritonService") << "unloadModel: Fallback server not found";
+    return false;
+  }
+
+  if (verbose_)
+    edm::LogInfo("TritonService") << "Model " << modelName << " ref count is 1, unloading from fallback server";
+
+  std::unique_ptr<tc::InferenceServerGrpcClient> client;
+  TRITON_THROW_IF_ERROR(tc::InferenceServerGrpcClient::Create(
+                            &client, sit->second.url, false, sit->second.useSsl, sit->second.sslOptions),
+                        "unloadModel: unable to create client for fallback server");
+
+  TRITON_THROW_IF_ERROR(client->UnloadModel(modelName),
+                        "unloadModel: failed to unload model " + modelName + " from fallback server");
+
+  model.refCount = 0;
+  model.servers.erase(Server::fallbackName);
+  sit->second.models.erase(modelName);
+  fallbackLoadedModels_.erase(modelName);
+
+  if (verbose_)
+    edm::LogInfo("TritonService") << "Successfully unloaded model " << modelName << " from fallback server";
+  return true;
 }

--- a/HeterogeneousCore/SonicTriton/test/BuildFile.xml
+++ b/HeterogeneousCore/SonicTriton/test/BuildFile.xml
@@ -1,11 +1,31 @@
 <test name="TestHeterogeneousCoreSonicTritonProducerCPU" command="unittest.sh ${LOCALTOP} CPU"/>
 <test name="TestHeterogeneousCoreSonicTritonProducerGPU" command="unittest.sh ${LOCALTOP} GPU"/>
+<test name="TestHeterogeneousCoreSonicTritonRetryActionSame" command="cmsRun ${LOCALTOP}/src/HeterogeneousCore/SonicTriton/test/tritonTest_cfg.py --modules TritonGraphProducer  --maxEvents 2 --unittest --device cpu --retryAction same"/>
+<test name="TestHeterogeneousCoreSonicTritonRetryActionDiff" command="cmsRun ${LOCALTOP}/src/HeterogeneousCore/SonicTriton/test/tritonTest_cfg.py --modules TritonGraphProducer  --maxEvents 2 --unittest --device cpu --retryAction diff"/>
 <test name="TestHeterogeneousCoreSonicTritonVersionCheck" command="cmsTritonConfigTool versioncheck">
   <use name="cmsswdata"/>
 </test>
-<library file="*.cc" name="testHeterogenousCoreSonicTriton">
+<library file="TritonGraphModules.cc, TritonIdentityProducer.cc, TritonImageProducer.cc, DynamicModelLoadingProducer.cc" name="testHeterogenousCoreSonicTriton">
   <flags EDM_PLUGIN="1"/>
   <use name="FWCore/ParameterSet"/>
   <use name="FWCore/Framework"/>
+  <use name="FWCore/ServiceRegistry"/>
   <use name="HeterogeneousCore/SonicTriton"/>
+  <use name="DataFormats/TestObjects"/>
 </library>
+
+<bin file="RetryActionDiffServer.cc" name="TestHeterogeneousCoreSonicTritonRetryActionDiffServer">
+  <use name="catch2"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="HeterogeneousCore/SonicTriton"/>
+</bin>
+
+<bin file="RefCount.cc" name="TestHeterogeneousCoreSonicTritonRefCount">
+  <use name="catch2"/>
+</bin>
+
+<test name="TestHeterogeneousCoreSonicTritonRetryActionDiff_Log" command="retry_action_diff_log_test.sh ${LOCALTOP}"/>
+
+<test name="TestHeterogeneousCoreSonicTritonDynamicModelLoadingSingleThread" command="cmsRun ${LOCALTOP}/src/HeterogeneousCore/SonicTriton/test/tritonTest_cfg.py --modules DynamicModelLoadingProducer --maxEvents 5 --loadUnloadCycles 3 --unittest --device cpu"/>
+<test name="TestHeterogeneousCoreSonicTritonDynamicModelLoadingConcurrent" command="cmsRun ${LOCALTOP}/src/HeterogeneousCore/SonicTriton/test/tritonTest_cfg.py --modules DynamicModelLoadingProducer --maxEvents 10 --loadUnloadCycles 5 --threads 10 --streams 10 --testConcurrency --unittest --device cpu"/>
+

--- a/HeterogeneousCore/SonicTriton/test/DynamicModelLoadingProducer.cc
+++ b/HeterogeneousCore/SonicTriton/test/DynamicModelLoadingProducer.cc
@@ -1,0 +1,83 @@
+#include "HeterogeneousCore/SonicTriton/interface/TritonEDProducer.h"
+#include "HeterogeneousCore/SonicTriton/interface/TritonService.h"
+#include "DataFormats/TestObjects/interface/ToyProducts.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+#include <memory>
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+// Test module that explicitly exercises dynamic model loading
+// This tests the reference counting and thread safety of loadModel/unloadModel
+class DynamicModelLoadingProducer : public TritonEDProducer<> {
+public:
+  explicit DynamicModelLoadingProducer(edm::ParameterSet const& cfg)
+      : TritonEDProducer<>(cfg),
+        loadUnloadCycles_(cfg.getParameter<int>("loadUnloadCycles")),
+        testConcurrency_(cfg.getParameter<bool>("testConcurrency")) {
+    putToken_ = produces<edmtest::IntProduct>();
+  }
+
+  void acquire(edm::Event const& iEvent, edm::EventSetup const& iSetup, Input& iInput) override {
+    edm::Service<TritonService> ts;
+    const std::string& modelName = client_->modelName();
+
+    // Test dynamic loading and unloading
+    if (testConcurrency_) {
+      // Stress test with multiple rapid load/unload cycles
+      for (int i = 0; i < loadUnloadCycles_; ++i) {
+        bool loadResult = ts->loadModel(modelName);
+        edm::LogInfo("DynamicModelLoadingProducer")
+            << "Load attempt " << i << ": " << (loadResult ? "success" : "failed");
+
+        // Small delay to allow other threads to interleave
+        if (i % 5 == 0) {
+          std::this_thread::yield();
+        }
+
+        bool unloadResult = ts->unloadModel(modelName);
+        edm::LogInfo("DynamicModelLoadingProducer")
+            << "Unload attempt " << i << ": " << (unloadResult ? "success" : "failed");
+      }
+    } else {
+      // Simple test: load once, unload once
+      bool loadResult = ts->loadModel(modelName);
+      edm::LogInfo("DynamicModelLoadingProducer") << "Single load: " << (loadResult ? "success" : "failed");
+
+      bool unloadResult = ts->unloadModel(modelName);
+      edm::LogInfo("DynamicModelLoadingProducer") << "Single unload: " << (unloadResult ? "success" : "failed");
+    }
+
+    // Fill dummy input - use actual input from the model (gat_test expects "x" input)
+    // This is just to satisfy the base class requirements, not for actual inference
+    auto& input_x = iInput.at("x");
+    auto data_x = input_x.allocate<float>();
+    // Minimal dummy data
+    (*data_x)[0] = std::vector<float>{1.0f};
+    input_x.setShape(0, 1, 0);
+    input_x.toServer(data_x);
+  }
+
+  void produce(edm::Event& iEvent, edm::EventSetup const& iSetup, Output const& iOutput) override {
+    // Produce dummy output
+    iEvent.emplace(putToken_, loadUnloadCycles_);
+  }
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    TritonClient::fillPSetDescription(desc);
+    desc.add<int>("loadUnloadCycles", 1);
+    desc.add<bool>("testConcurrency", false);
+    descriptions.addWithDefaultLabel(desc);
+  }
+
+private:
+  int loadUnloadCycles_;
+  bool testConcurrency_;
+  edm::EDPutTokenT<edmtest::IntProduct> putToken_;
+};
+
+DEFINE_FWK_MODULE(DynamicModelLoadingProducer);

--- a/HeterogeneousCore/SonicTriton/test/RefCount.cc
+++ b/HeterogeneousCore/SonicTriton/test/RefCount.cc
@@ -1,0 +1,199 @@
+#define CATCH_CONFIG_MAIN
+#include "catch2/catch_all.hpp"
+
+#include <string>
+#include <unordered_map>
+#include <mutex>
+
+// Standalone refcount logic test
+// This tests the refcount algorithm without requiring the full TritonService infrastructure
+
+// Simplified model state for testing refcount logic
+struct TestModelState {
+  std::string modelName;
+  std::string path;
+  int refCount{0};
+  bool isLoaded() const { return refCount > 0; }
+};
+
+// Mock class that implements the same refcount logic as TritonService
+class RefCountManager {
+public:
+  // Tracks actual server load/unload calls
+  int serverLoadCalls{0};
+  int serverUnloadCalls{0};
+
+  // Simulates loadModel behavior
+  bool loadModel(const std::string& modelName, const std::string& path = "") {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    auto& state = models_[modelName];
+    if (state.modelName.empty())
+      state.modelName = modelName;
+    if (state.path.empty() && !path.empty())
+      state.path = path;
+
+    // If already loaded, just bump refcount (no server call)
+    if (state.refCount > 0) {
+      ++state.refCount;
+      refCounts_[modelName] = state.refCount;
+      return true;
+    }
+
+    // Actually "load" on server (simulated)
+    ++serverLoadCalls;
+    state.refCount = 1;
+    refCounts_[modelName] = state.refCount;
+    return true;
+  }
+
+  // Simulates unloadModel behavior
+  bool unloadModel(const std::string& modelName) {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    auto it = models_.find(modelName);
+    if (it == models_.end() || it->second.refCount == 0) {
+      return false;  // Not loaded
+    }
+
+    auto& state = it->second;
+
+    // If refcount > 1, just decrement (no server call)
+    if (state.refCount > 1) {
+      --(state.refCount);
+      refCounts_[modelName] = state.refCount;
+      return true;
+    }
+
+    // Actually "unload" from server (simulated)
+    ++serverUnloadCalls;
+    refCounts_.erase(modelName);
+    state.refCount = 0;
+    return true;
+  }
+
+  int getRefCount(const std::string& modelName) const {
+    auto it = refCounts_.find(modelName);
+    return (it != refCounts_.end()) ? it->second : 0;
+  }
+
+private:
+  std::unordered_map<std::string, TestModelState> models_;
+  std::unordered_map<std::string, int> refCounts_;
+  std::mutex mutex_;
+};
+
+TEST_CASE("RefCount: single load increments to 1", "[RefCount]") {
+  RefCountManager mgr;
+
+  REQUIRE(mgr.loadModel("model_a", "/path/to/model_a"));
+  REQUIRE(mgr.getRefCount("model_a") == 1);
+  REQUIRE(mgr.serverLoadCalls == 1);
+}
+
+TEST_CASE("RefCount: multiple loads increment without server calls", "[RefCount]") {
+  RefCountManager mgr;
+
+  // First load - should call server
+  REQUIRE(mgr.loadModel("model_a"));
+  REQUIRE(mgr.getRefCount("model_a") == 1);
+  REQUIRE(mgr.serverLoadCalls == 1);
+
+  // Second load - should NOT call server, just increment
+  REQUIRE(mgr.loadModel("model_a"));
+  REQUIRE(mgr.getRefCount("model_a") == 2);
+  REQUIRE(mgr.serverLoadCalls == 1);  // Still 1
+
+  // Third load - should NOT call server, just increment
+  REQUIRE(mgr.loadModel("model_a"));
+  REQUIRE(mgr.getRefCount("model_a") == 3);
+  REQUIRE(mgr.serverLoadCalls == 1);  // Still 1
+}
+
+TEST_CASE("RefCount: unload decrements without server call until zero", "[RefCount]") {
+  RefCountManager mgr;
+
+  // Load 3 times
+  mgr.loadModel("model_a");
+  mgr.loadModel("model_a");
+  mgr.loadModel("model_a");
+  REQUIRE(mgr.getRefCount("model_a") == 3);
+  REQUIRE(mgr.serverLoadCalls == 1);
+
+  // First unload - decrement only, no server call
+  REQUIRE(mgr.unloadModel("model_a"));
+  REQUIRE(mgr.getRefCount("model_a") == 2);
+  REQUIRE(mgr.serverUnloadCalls == 0);
+
+  // Second unload - decrement only, no server call
+  REQUIRE(mgr.unloadModel("model_a"));
+  REQUIRE(mgr.getRefCount("model_a") == 1);
+  REQUIRE(mgr.serverUnloadCalls == 0);
+
+  // Third unload - should call server (refcount reaches 0)
+  REQUIRE(mgr.unloadModel("model_a"));
+  REQUIRE(mgr.getRefCount("model_a") == 0);
+  REQUIRE(mgr.serverUnloadCalls == 1);
+}
+
+TEST_CASE("RefCount: unload on non-loaded model returns false", "[RefCount]") {
+  RefCountManager mgr;
+
+  // Unload without loading first
+  REQUIRE_FALSE(mgr.unloadModel("model_a"));
+  REQUIRE(mgr.serverUnloadCalls == 0);
+}
+
+TEST_CASE("RefCount: reload after full unload triggers new server load", "[RefCount]") {
+  RefCountManager mgr;
+
+  // Load and fully unload
+  mgr.loadModel("model_a");
+  mgr.unloadModel("model_a");
+  REQUIRE(mgr.getRefCount("model_a") == 0);
+  REQUIRE(mgr.serverLoadCalls == 1);
+  REQUIRE(mgr.serverUnloadCalls == 1);
+
+  // Reload - should call server again
+  REQUIRE(mgr.loadModel("model_a"));
+  REQUIRE(mgr.getRefCount("model_a") == 1);
+  REQUIRE(mgr.serverLoadCalls == 2);  // Now 2
+}
+
+TEST_CASE("RefCount: multiple models are independent", "[RefCount]") {
+  RefCountManager mgr;
+
+  // Load two different models
+  mgr.loadModel("model_a");
+  mgr.loadModel("model_b");
+  REQUIRE(mgr.getRefCount("model_a") == 1);
+  REQUIRE(mgr.getRefCount("model_b") == 1);
+  REQUIRE(mgr.serverLoadCalls == 2);
+
+  // Load model_a again
+  mgr.loadModel("model_a");
+  REQUIRE(mgr.getRefCount("model_a") == 2);
+  REQUIRE(mgr.getRefCount("model_b") == 1);
+  REQUIRE(mgr.serverLoadCalls == 2);  // No new server call
+
+  // Unload model_b completely
+  mgr.unloadModel("model_b");
+  REQUIRE(mgr.getRefCount("model_a") == 2);
+  REQUIRE(mgr.getRefCount("model_b") == 0);
+  REQUIRE(mgr.serverUnloadCalls == 1);
+
+  // model_a still loaded
+  REQUIRE(mgr.getRefCount("model_a") == 2);
+}
+
+TEST_CASE("RefCount: path is preserved from first load", "[RefCount]") {
+  RefCountManager mgr;
+
+  // First load with path
+  mgr.loadModel("model_a", "/path/to/model");
+  REQUIRE(mgr.getRefCount("model_a") == 1);
+
+  // Second load without path - should still work
+  mgr.loadModel("model_a");
+  REQUIRE(mgr.getRefCount("model_a") == 2);
+}

--- a/HeterogeneousCore/SonicTriton/test/RetryActionDiffServer.cc
+++ b/HeterogeneousCore/SonicTriton/test/RetryActionDiffServer.cc
@@ -1,0 +1,71 @@
+#define CATCH_CONFIG_MAIN
+#include "catch2/catch_all.hpp"
+
+#include "HeterogeneousCore/SonicTriton/interface/RetryActionDiffServer.h"
+#include "HeterogeneousCore/SonicTriton/interface/TritonClient.h"
+#include "HeterogeneousCore/SonicTriton/interface/TritonService.h"
+#include "HeterogeneousCore/SonicCore/interface/RetryActionBase.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include <string>
+
+// Test double for TritonClient to observe updateServer calls without framework/services
+class TestTritonClient : public TritonClient {
+public:
+  TestTritonClient() : TritonClient() {}
+
+  void connectToServer(const std::string& url) override { lastConnectedUrl = url; }
+
+  void updateServer(const std::string& serverName) override { lastUpdatedServerName = serverName; }
+
+  const std::string& lastUrl() const { return lastConnectedUrl; }
+  const std::string& lastServerName() const { return lastUpdatedServerName; }
+
+protected:
+  void evaluate() override {}
+
+private:
+  std::string lastConnectedUrl;
+  std::string lastUpdatedServerName;
+};
+
+TEST_CASE("RetryActionDiffServer switches to fallback via updateServer", "[RetryActionDiffServer]") {
+  edm::ParameterSet empty;
+  TestTritonClient client;
+
+  RetryActionDiffServer action(empty, static_cast<SonicClientBase*>(&client));
+
+  // start should arm the action
+  action.start();
+  REQUIRE(action.shouldRetry());
+
+  // retry should call updateServer with fallback name then disarm
+  action.retry();
+  REQUIRE(client.lastServerName() == TritonService::Server::fallbackName);
+
+  // second retry without re-arming should be a no-op: lastServerName unchanged
+  std::string afterFirst = client.lastServerName();
+  action.retry();
+  REQUIRE(client.lastServerName() == afterFirst);
+}
+
+// A client that throws during updateServer to exercise error handling path
+class ThrowingTritonClient : public TritonClient {
+public:
+  ThrowingTritonClient() : TritonClient() {}
+  void updateServer(const std::string&) override { throw TritonException("updateServer failure"); }
+
+protected:
+  void evaluate() override {}
+};
+
+TEST_CASE("RetryActionDiffServer catches exceptions from updateServer", "[RetryActionDiffServer]") {
+  edm::ParameterSet empty;
+  ThrowingTritonClient client;
+  RetryActionDiffServer action(empty, static_cast<SonicClientBase*>(&client));
+  action.start();
+
+  // Should not throw despite client throwing internally; action disarms afterward
+  REQUIRE_NOTHROW(action.retry());
+}

--- a/HeterogeneousCore/SonicTriton/test/tritonTest_cfg.py
+++ b/HeterogeneousCore/SonicTriton/test/tritonTest_cfg.py
@@ -9,6 +9,7 @@ models = {
     "TritonGraphFilter": ["gat_test"],
     "TritonGraphAnalyzer": ["gat_test"],
     "TritonIdentityProducer": ["ragged_io"],
+    "DynamicModelLoadingProducer": ["gat_test"],
 }
 
 # other choices
@@ -21,6 +22,9 @@ parser.add_argument("--mode", default="Async", type=str, choices=allowed_modes, 
 parser.add_argument("--brief", default=False, action="store_true", help="briefer output for graph modules")
 parser.add_argument("--unittest", default=False, action="store_true", help="unit test mode: reduce input sizes")
 parser.add_argument("--testother", default=False, action="store_true", help="also test gRPC communication if shared memory enabled, or vice versa")
+parser.add_argument("--loadUnloadCycles", default=3, type=int, help="number of load/unload cycles for dynamic model loading test")
+parser.add_argument("--testConcurrency", default=False, action="store_true", help="enable concurrent stress test for dynamic model loading")
+options = parser.parse_args()
 
 options = getOptions(parser, verbose=True)
 
@@ -83,6 +87,10 @@ for im,module in enumerate(options.modules):
             processModule.edgeMin = cms.uint32(8000)
             processModule.edgeMax = cms.uint32(15000)
         processModule.brief = cms.bool(options.brief)
+    elif module=="DynamicModelLoadingProducer":
+        # Configure dynamic model loading test (requires explicit model control mode, enabled by default in cmsTriton)
+        processModule.loadUnloadCycles = cms.int32(options.loadUnloadCycles)
+        processModule.testConcurrency = cms.bool(options.testConcurrency)
     process.p += processModule
     if options.testother:
         # clone modules to test both gRPC and shared memory


### PR DESCRIPTION
#### PR description:

Introduces a pluggable retry mechanism for SONIC inference clients and dynamic
model loading/unloading on the Triton fallback server. This enables automatic
recovery when a remote Triton server becomes unavailable during event processing.
#### Retry mechanism (`SonicCore`)
- **`RetryActionBase`**: Plugin factory base class for retry strategies, with
  `retry()`, `start()`, `finish()` interface
- **`RetrySameServerAction`**: Retries inference on the same server (configurable
  `allowedTries`)
- **`SonicClientBase::finish()`**: Drives retry loop — on retryable failure
  (`finish(false)`), iterates through registered retry actions; on non-retryable
  failure (`finish(false, eptr)`), propagates exception directly
#### Retry with server failover (`SonicTriton`)
- **`RetryActionDiffServer`**: On failure, queries `TritonService::getBestServer()`
  for an alternative healthy remote server, calls `updateServer()` + `eval()` to
  retry on the new server
- **`RetryFallbackServerAction`**: Last-resort action — when all other retries are
  exhausted, lazily starts the fallback server (idempotent), dynamically loads the
  model to the fallback server via `TritonClient::switchToFallback()`, and retries locally. Fires at most
  once per inference call.
- **Server health tracking**: `TritonService` maintains per-server health stats
  (liveness, readiness, failure count, queue time) via `updateServerHealth()`,
  used by `getBestServer()` to select the best candidate
- **Server selection preference**: `resolveServerName()` prefers remote (non-fallback)
  servers when multiple servers provide the same model; `getBestServer()` excludes
  fallback servers from candidate pool

#### Async retry redesign (holder-based)
- `evaluate()` (Async mode) creates an inner `WaitingTaskWithArenaHolder` per
  inference attempt — the gRPC callback calls `doneWaiting()` and returns
  immediately; `finish()`/`retry()`/`updateServer()` are scheduled as TBB tasks
#### Dynamic model loading (`TritonService`)
- `loadModel()`/`unloadModel()` with reference counting for the fallback server
- `startFallbackServer()` is idempotent; only started at `preBeginJob` for
  unassigned models (no remote server available)
- Fallback server health entry properly registered in `serversHealth_`
### Configuration
- Retry actions configurable via `Retry` VPSet in client config
  (`retryType`, `allowedTries`)
- `customize.py` updated with retry options, defaulted to add `RetryFallbackServerAction` as the last action.

#### PR validation:

[retry_diffServer_fallback.log](https://github.com/user-attachments/files/29271888/retry_diffServer_fallback.log)

